### PR TITLE
makefsdata: Support using the system's zlib instead of only minizip for deflate compression...

### DIFF
--- a/src/apps/http/makefsdata/makefsdata.c
+++ b/src/apps/http/makefsdata/makefsdata.c
@@ -21,16 +21,25 @@
 
 /** Makefsdata can generate *all* files deflate-compressed (where file size shrinks).
  * Since nearly all browsers support this, this is a good way to reduce ROM size.
- * To compress the files, "miniz.c" must be downloaded separately.
+ * To compress the files, "miniz.c" must be downloaded separately OR
+ * MAKEFS_SUPPORT_DEFLATE_ZLIB must be set and the zlib library and headers
+ * must be present on the system compiling this program.
  */
 #ifndef MAKEFS_SUPPORT_DEFLATE
 #define MAKEFS_SUPPORT_DEFLATE 0
-#endif
+#ifndef MAKEFS_SUPPORT_DEFLATE_ZLIB
+#define MAKEFS_SUPPORT_DEFLATE_ZLIB 0
+#endif // MAKEFS_SUPPORT_DEFLATE_ZLIB
+#endif // MAKEFS_SUPPORT_DEFLATE
 
 #define COPY_BUFSIZE (1024*1024) /* 1 MByte */
 
 #if MAKEFS_SUPPORT_DEFLATE
+#if MAKEFS_SUPPORT_DEFLATE_ZLIB
+#include <zlib.h>
+#else
 #include "../miniz.c"
+#endif // MAKEFS_SUPPORT_DEFLATE
 
 typedef unsigned char uint8;
 typedef unsigned short uint16;
@@ -49,9 +58,11 @@ typedef unsigned int uint;
 static uint8 s_outbuf[OUT_BUF_SIZE];
 static uint8 s_checkbuf[OUT_BUF_SIZE];
 
+#ifndef MAKEFS_SUPPORT_DEFLATE_ZLIB
 /* tdefl_compressor contains all the state needed by the low-level compressor so it's a pretty big struct (~300k).
    This example makes it a global vs. putting it on the stack, of course in real-world usage you'll probably malloc() or new it. */
 tdefl_compressor g_deflator;
+#endif // MAKEFS_SUPPORT_DEFLATE_ZLIB
 
 static int deflate_level; /* default compression level, can be changed via command line */
 #define USAGE_ARG_DEFLATE " [-defl<:compr_level>]"
@@ -587,11 +598,17 @@ static u8_t *get_file_data(const char *filename, int *file_size, int can_be_comp
     if (can_be_compressed) {
       if (fsize < OUT_BUF_SIZE) {
         u8_t *ret_buf;
+#ifndef MAKEFS_SUPPORT_DEFLATE_ZLIB
         tdefl_status status;
+#else
+        int status;
+#endif // MAKEFS_SUPPORT_DEFLATE_ZLIB
         size_t in_bytes = fsize;
         size_t out_bytes = OUT_BUF_SIZE;
         const void *next_in = buf;
         void *next_out = s_outbuf;
+        memset(s_outbuf, 0, sizeof(s_outbuf));
+#ifndef MAKEFS_SUPPORT_DEFLATE_ZLIB
         /* create tdefl() compatible flags (we have to compose the low-level flags ourselves, or use tdefl_create_comp_flags_from_zip_params() but that means MINIZ_NO_ZLIB_APIS can't be defined). */
         mz_uint comp_flags = s_tdefl_num_probes[MZ_MIN(10, deflate_level)] | ((deflate_level <= 3) ? TDEFL_GREEDY_PARSING_FLAG : 0);
         if (!deflate_level) {
@@ -602,12 +619,18 @@ static u8_t *get_file_data(const char *filename, int *file_size, int can_be_comp
           printf("tdefl_init() failed!\n");
           exit(-1);
         }
-        memset(s_outbuf, 0, sizeof(s_outbuf));
         status = tdefl_compress(&g_deflator, next_in, &in_bytes, next_out, &out_bytes, TDEFL_FINISH);
         if (status != TDEFL_STATUS_DONE) {
           printf("deflate failed: %d\n", status);
           exit(-1);
         }
+#else
+        status = compress2(next_out, &out_bytes, next_in, in_bytes, deflate_level);
+        if (status != Z_OK) {
+          printf("deflate failed: %d\n", status);
+          exit(-1);
+        }
+#endif // MAKEFS_SUPPORT_DEFLATE_ZLIB
         LWIP_ASSERT("out_bytes <= COPY_BUFSIZE", out_bytes <= OUT_BUF_SIZE);
         if (out_bytes < fsize) {
           ret_buf = (u8_t *)malloc(out_bytes);
@@ -615,16 +638,22 @@ static u8_t *get_file_data(const char *filename, int *file_size, int can_be_comp
           memcpy(ret_buf, s_outbuf, out_bytes);
           {
             /* sanity-check compression be inflating and comparing to the original */
-            tinfl_status dec_status;
-            tinfl_decompressor inflator;
             size_t dec_in_bytes = out_bytes;
             size_t dec_out_bytes = OUT_BUF_SIZE;
             next_out = s_checkbuf;
+            memset(s_checkbuf, 0, sizeof(s_checkbuf));
+#ifndef MAKEFS_SUPPORT_DEFLATE_ZLIB
+            tinfl_status dec_status;
+            tinfl_decompressor inflator;
 
             tinfl_init(&inflator);
-            memset(s_checkbuf, 0, sizeof(s_checkbuf));
             dec_status = tinfl_decompress(&inflator, (const mz_uint8 *)ret_buf, &dec_in_bytes, s_checkbuf, (mz_uint8 *)next_out, &dec_out_bytes, 0);
             LWIP_ASSERT("tinfl_decompress failed", dec_status == TINFL_STATUS_DONE);
+#else
+            int dec_status;
+            dec_status = uncompress2 (s_checkbuf, &dec_out_bytes, ret_buf, &dec_in_bytes);
+            LWIP_ASSERT("tinfl_decompress failed", dec_status == Z_OK);
+#endif // MAKEFS_SUPPORT_DEFLATE_ZLIB
             LWIP_ASSERT("tinfl_decompress size mismatch", fsize == dec_out_bytes);
             LWIP_ASSERT("decompressed memcmp failed", !memcmp(s_checkbuf, buf, fsize));
           }

--- a/src/apps/http/makefsdata/readme.txt
+++ b/src/apps/http/makefsdata/readme.txt
@@ -11,3 +11,13 @@ Usage: htmlgen [targetdir] [-s] [-i]s
 
   if targetdir not specified, makefsdata will attempt to
   process files in subdirectory 'fs'.
+
+The C version of this program can optionally store the none-SSI files in
+a compressed form in which they are also sent to the web client (which
+must support the Deflate content encoding). Files that grow during compression
+(due to being not compressible well), will stored umcompressed automatically.
+In order to do so, compile the program with MAKEFS_SUPPORT_DEFLATE set to 1. You must
+manually download minizip.c for this to work. As an alternative, you can additionally
+define MAKEFS_SUPPORT_DEFLATE_ZLIB to use your system's zlib instead.
+Compression of .html, .js, .css and .svg files usually yields very good compression
+rates and is a great way of reducing your program's size.


### PR DESCRIPTION
… and also note so in the readme

Background: I am using lwip's awesome http server on a Raspberry Pi Pico board that has "only" 2MByte of flash memory. In order to save space and since I know that HTML, JS, CSS and SVG files compress very well, I thought of adding this feature ti makefsdata.c. I investigated a bit and settled on brotli compression. When it was finished (https://github.com/lwip-tcpip/lwip/compare/master...kripton:brotli), I found out that basically all browser only support brotli on https connections. However, I was delighted that makefadata already supports deflate compression. Unfortunately, the file minizip.c needs to be manually downloaded and put into the source folder. To avoid this, I extended it to use the system's zlib instead, which is usually already present on most GNU/Linux systems.