### PR TITLE
tcp_in : fix ooseq update error

### DIFF
--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -1687,6 +1687,15 @@ tcp_receive(struct tcp_pcb *pcb)
                  ->ooseq. We check the lengths to see which one to
                  discard. */
               if (inseg.len > next->len) {
+
+                /*if next segment is the last segment in ooseq
+                  and smaller than inseg,means it has been trimed before
+                  to fit our windows,so we just break here.
+                */
+                if(next->next == NULL){
+                  break;
+                }
+
                 /* The incoming segment is larger than the old
                    segment. We replace some segments with the new
                    one. */


### PR DESCRIPTION
if a pbuf received with the same seqno in ooseq ,
we then check  the size and replace the existing one
with the larger one,but if the existing one is the
last segment in ooseq ,it might has been trimed before.
the replacing action will overrun our receive windows