### PR TITLE
Fix custom LWIP_PLATFORM_DIAG

### DIFF
--- a/src/include/lwip/debug.h
+++ b/src/include/lwip/debug.h
@@ -37,8 +37,8 @@
 #ifndef LWIP_HDR_DEBUG_H
 #define LWIP_HDR_DEBUG_H
 
-#include "lwip/arch.h"
 #include "lwip/opt.h"
+#include "lwip/arch.h"
 
 /**
  * @defgroup debugging_levels LWIP_DBG_MIN_LEVEL and LWIP_DBG_TYPES_ON values


### PR DESCRIPTION
When you define your own LWIP_PLATFORM_DIAG macro, the warning redefinition appeared