### PR TITLE
netif: fix the netif's index error

### DIFF
--- a/src/netif/ethernet.c
+++ b/src/netif/ethernet.c
@@ -96,10 +96,6 @@ ethernet_input(struct pbuf *p, struct netif *netif)
     goto free_and_return;
   }
 
-  if (p->if_idx == NETIF_NO_INDEX) {
-    p->if_idx = netif_get_index(netif);
-  }
-
   /* points to packet payload, which starts with an Ethernet header */
   ethhdr = (struct eth_hdr *)p->payload;
   LWIP_DEBUGF(ETHARP_DEBUG | LWIP_DBG_TRACE,
@@ -142,6 +138,10 @@ ethernet_input(struct pbuf *p, struct netif *netif)
 #if LWIP_ARP_FILTER_NETIF
   netif = LWIP_ARP_FILTER_NETIF_FN(p, netif, lwip_htons(type));
 #endif /* LWIP_ARP_FILTER_NETIF*/
+
+  if (p->if_idx == NETIF_NO_INDEX) {
+    p->if_idx = netif_get_index(netif);
+  }
 
   if (ethhdr->dest.addr[0] & 1) {
     /* this might be a multicast or broadcast packet */


### PR DESCRIPTION
When using multiple netifs on one hardware interface (e.g. when mapping multiple IP addresses to one hardware interface), if the netif's low-level receive routine cannot decide for the correct netif, here the `netif` parameter may be a default netif, in this case, `p-> if_idx` will get a wrong netif index value. It should be placed after `netif = LWIP_ARP_FILTER_NETIF_FN(p, netif, lwip_htons(type));`.  Filter function can returns the correct netif before assigning `p-> if_idx`.