### PR TITLE
mDNS : implement service subtype to the LwIP mDNS application

### DIFF
--- a/src/apps/mdns/mdns.c
+++ b/src/apps/mdns/mdns.c
@@ -2507,10 +2507,12 @@ mdns_resp_netif_active(struct netif *netif)
  * @param txt_fn Callback to get TXT data. Will be called each time a TXT reply is created to
  *               allow dynamic replies.
  * @param txt_data Userdata pointer for txt_fn
+ * @param subTypes table contanins all subtypes of the service
+ * param subtypes_nbr the number of the subtypes linked to that service, it should be <=MDNS_MAX_SERVICES_SUBTYPES
  * @return service_id if the service was added to the netif, an err_t otherwise
  */
 s8_t
-mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_data)
+mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_data, char **subTypes,  u8_t subtypes_nbr )
 {
   u8_t slot;
   struct mdns_service *srv;
@@ -2537,10 +2539,13 @@ mdns_resp_add_service(struct netif *netif, const char *name, const char *service
 
   MEMCPY(&srv->name, name, LWIP_MIN(MDNS_LABEL_MAXLEN, strlen(name)));
   MEMCPY(&srv->service, service, LWIP_MIN(MDNS_LABEL_MAXLEN, strlen(service)));
+  for(i=0;i<LWIP_MIN(subtypes_nbr,MDNS_MAX_SERVICES_SUBTYPES);i++)
+      MEMCPY(&srv->subTypes[i], subTypes[i], LWIP_MIN(MDNS_LABEL_MAXLEN, strlen(subTypes[i])));
   srv->txt_fn = txt_fn;
   srv->txt_userdata = txt_data;
   srv->proto = (u16_t)proto;
   srv->port = port;
+  srv->subtypes_nbr = subtypes_nbr;
 
   mdns->services[slot] = srv;
 

--- a/src/apps/mdns/mdns.c
+++ b/src/apps/mdns/mdns.c
@@ -2514,7 +2514,7 @@ mdns_resp_netif_active(struct netif *netif)
 s8_t
 mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_data, char **subTypes,  u8_t subtypes_nbr )
 {
-  u8_t slot;
+  u8_t slot,i;
   struct mdns_service *srv;
   struct mdns_host *mdns;
 

--- a/src/apps/mdns/mdns_domain.c
+++ b/src/apps/mdns/mdns_domain.c
@@ -632,4 +632,30 @@ mdns_write_domain(struct mdns_outpacket *outpkt, struct mdns_domain *domain)
   return ERR_OK;
 }
 
+/**
+ * Build domain name for a subtype service
+ * @param domain Where to write the domain name
+ * @param service The service struct, containing service name, type and protocol
+ * @param include_name Whether to include the service name in the domain
+ * @return ERR_OK if domain was written. If service name is included,
+ *         \<subType\>.\<_sub\>.\<type\>.\<proto\>.local. will be written, otherwise \<type\>.\<proto\>.local.
+ *         An err_t is returned on error.
+ */
+err_t
+mdns_build_subtype_service_domain(struct mdns_domain *domain, struct mdns_service *service, int subTypes_index)
+{
+  err_t res;
+  LWIP_UNUSED_ARG(res);
+  memset(domain, 0, sizeof(struct mdns_domain));
+  res = mdns_domain_add_label(domain, service->subTypes[subTypes_index], strlen(service->subTypes[subTypes_index]));
+  LWIP_ERROR("mdns_build_service_domain: Failed to add label", (res == ERR_OK), return res);
+  res = mdns_domain_add_label(domain, "_sub", 4);
+  LWIP_ERROR("mdns_build_service_domain: Failed to add label", (res == ERR_OK), return res);
+  res = mdns_domain_add_label(domain, service->service, (u8_t)strlen(service->service));
+  LWIP_ERROR("mdns_build_service_domain: Failed to add label", (res == ERR_OK), return res);
+  res = mdns_domain_add_label(domain, dnssd_protos[service->proto], (u8_t)strlen(dnssd_protos[service->proto]));
+  LWIP_ERROR("mdns_build_service_domain: Failed to add label", (res == ERR_OK), return res);
+  return mdns_add_dotlocal(domain);
+}
+
 #endif /* LWIP_MDNS_RESPONDER */

--- a/src/apps/mdns/mdns_out.c
+++ b/src/apps/mdns/mdns_out.c
@@ -54,7 +54,7 @@
 
 /* Function prototypes */
 static void mdns_clear_outmsg(struct mdns_outmsg *outmsg);
-mdns_add_service_subtype_ptr_answer(struct mdns_outpacket *reply, struct mdns_outmsg *msg, struct mdns_service *service);
+static err_t mdns_add_service_subtype_ptr_answer(struct mdns_outpacket *reply, struct mdns_outmsg *msg, struct mdns_service *service);
 /**
  * Call user supplied function to setup TXT data
  * @param service The service to build TXT record for

--- a/src/include/lwip/apps/mdns.h
+++ b/src/include/lwip/apps/mdns.h
@@ -112,7 +112,7 @@ err_t mdns_resp_remove_netif(struct netif *netif);
 err_t mdns_resp_rename_netif(struct netif *netif, const char *hostname);
 int mdns_resp_netif_active(struct netif *netif);
 
-s8_t  mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_userdata);
+s8_t  mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_data, char **subTypes,  u8_t subtypes_nbr )
 err_t mdns_resp_del_service(struct netif *netif, u8_t slot);
 err_t mdns_resp_rename_service(struct netif *netif, u8_t slot, const char *name);
 

--- a/src/include/lwip/apps/mdns.h
+++ b/src/include/lwip/apps/mdns.h
@@ -112,7 +112,7 @@ err_t mdns_resp_remove_netif(struct netif *netif);
 err_t mdns_resp_rename_netif(struct netif *netif, const char *hostname);
 int mdns_resp_netif_active(struct netif *netif);
 
-s8_t  mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_data, char **subTypes,  u8_t subtypes_nbr )
+s8_t  mdns_resp_add_service(struct netif *netif, const char *name, const char *service, enum mdns_sd_proto proto, u16_t port, service_get_txt_fn_t txt_fn, void *txt_data, char **subTypes,  u8_t subtypes_nbr );
 err_t mdns_resp_del_service(struct netif *netif, u8_t slot);
 err_t mdns_resp_rename_service(struct netif *netif, u8_t slot, const char *name);
 

--- a/src/include/lwip/apps/mdns_domain.h
+++ b/src/include/lwip/apps/mdns_domain.h
@@ -70,7 +70,7 @@ err_t mdns_build_request_domain(struct mdns_domain *domain, struct mdns_request 
 #endif
 u16_t mdns_compress_domain(struct pbuf *pbuf, u16_t *offset, struct mdns_domain *domain);
 err_t mdns_write_domain(struct mdns_outpacket *outpkt, struct mdns_domain *domain);
-
+err_t mdns_build_subtype_service_domain(struct mdns_domain *domain, struct mdns_service *service, int subTypes_index);
 #endif /* LWIP_MDNS_RESPONDER */
 
 #ifdef __cplusplus

--- a/src/include/lwip/apps/mdns_opts.h
+++ b/src/include/lwip/apps/mdns_opts.h
@@ -52,7 +52,7 @@
  * transport. IGMP is needed for IPv4 multicast.
  */
 #ifndef LWIP_MDNS_RESPONDER
-#define LWIP_MDNS_RESPONDER             0
+#define LWIP_MDNS_RESPONDER             1
 #endif /* LWIP_MDNS_RESPONDER */
 
 /** The maximum number of services per netif */

--- a/src/include/lwip/apps/mdns_opts.h
+++ b/src/include/lwip/apps/mdns_opts.h
@@ -58,6 +58,8 @@
 /** The maximum number of services per netif */
 #ifndef MDNS_MAX_SERVICES
 #define MDNS_MAX_SERVICES               1
+/** The maximum number of subtypes per service */
+#define MDNS_MAX_SERVICES_SUBTYPES      4
 #endif
 
 /** The minimum delay between probes in ms. RFC 6762 require 250ms.

--- a/src/include/lwip/apps/mdns_priv.h
+++ b/src/include/lwip/apps/mdns_priv.h
@@ -98,14 +98,18 @@ struct mdns_service {
   char name[MDNS_LABEL_MAXLEN + 1];
   /** Type of service, like '_http' */
   char service[MDNS_LABEL_MAXLEN + 1];
-  /** Callback function and userdata
-   * to update txtdata buffer */
+  /** SubType of service, like '_printer' */
+  char subTypes[MDNS_MAX_SERVICES_SUBTYPES][MDNS_LABEL_MAXLEN + 1];
+  /** Callback function and userdata/*
+   /* to update txtdata buffer */
   service_get_txt_fn_t txt_fn;
   void *txt_userdata;
   /** Protocol, TCP or UDP */
   u16_t proto;
   /** Port of the service */
   u16_t port;
+  /** Number of the subtypes of a service */
+  u16_t subtypes_nbr;
 };
 
 /** mDNS output packet */


### PR DESCRIPTION
There are a lot of service types that are not in the standard (RFC 2782) as "_printer" for example. And in some circumstances in order to advertise a particular service or to be detected by other mdns applications that filter only some particular types, we need to use subtypes for that purpose.
The following pull request proposes an implementation of a service subtype in the LwIP mDNS application.
The solution is based on writing an answer of a subtype service PTR RR into the outpacket. In order to do that I made the following changes :

1. Update the service structure to contain a table of subtypes ( because a service can have many subtypes)
2. Update the mdns_resp_add_service() function to initialize the subtypes of a service
3. Add mdns_add_service_subtype_ptr_answer() function that writes answer of the subtype service PTR RR to outpacket

Useful : 
To initialize a service with two subtypes we need to
-  update the maximum subtype services number to 2 or more

> #define MDNS_MAX_SERVICES_SUBTYPES      2

- Call the function mdns_resp_add_service as follows

> char *subtype[]={"_iot_node","_printer"};

>  mdns_resp_add_service(gnetif, "ServiceTest1", "_rtsp", DNSSD_PROTO_TCP, 9090, srv_txt, NULL,subtype,2);

For testing purpose,  for example to browse only "_printer" subtypes we can use the following command line on Linux (not that the subtypes are not displayed in the avahi graphical interface): 

> avahi-browse _printer._sub._rtsp._tcp