### PR TITLE
feat(dhcp): client identifier option

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -224,6 +224,9 @@ static u16_t dhcp_option_long(u16_t options_out_len, u8_t *options, u32_t value)
 #if LWIP_NETIF_HOSTNAME
 static u16_t dhcp_option_hostname(u16_t options_out_len, u8_t *options, struct netif *netif);
 #endif /* LWIP_NETIF_HOSTNAME */
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+static u16_t dhcp_option_client_identifier(u16_t options_out_len, u8_t *options, struct pbuf *p_out);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 /* always add the DHCP options trailer to end and pad */
 static void dhcp_option_trailer(u16_t options_out_len, u8_t *options, struct pbuf *p_out);
 
@@ -440,6 +443,10 @@ dhcp_select(struct netif *netif)
 #if LWIP_NETIF_HOSTNAME
     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
 #endif /* LWIP_NETIF_HOSTNAME */
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 
     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_REQUESTING, msg_out, DHCP_REQUEST, &options_out_len);
     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
@@ -952,6 +959,10 @@ dhcp_decline(struct netif *netif)
     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_REQUESTED_IP, 4);
     options_out_len = dhcp_option_long(options_out_len, msg_out->options, lwip_ntohl(ip4_addr_get_u32(&dhcp->offered_ip_addr)));
 
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
+
     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_BACKING_OFF, msg_out, DHCP_DECLINE, &options_out_len);
     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
 
@@ -1002,6 +1013,14 @@ dhcp_discover(struct netif *netif)
 
     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_MAX_MSG_SIZE, DHCP_OPTION_MAX_MSG_SIZE_LEN);
     options_out_len = dhcp_option_short(options_out_len, msg_out->options, DHCP_MAX_MSG_LEN(netif));
+
+#if LWIP_NETIF_HOSTNAME
+    options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
+#endif /* LWIP NETIF HOSTNAME */
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 
     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_PARAMETER_REQUEST_LIST, LWIP_ARRAYSIZE(dhcp_discover_request_options));
     for (i = 0; i < LWIP_ARRAYSIZE(dhcp_discover_request_options); i++) {
@@ -1160,6 +1179,10 @@ dhcp_renew(struct netif *netif)
     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
 #endif /* LWIP_NETIF_HOSTNAME */
 
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
+
     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_RENEWING, msg_out, DHCP_REQUEST, &options_out_len);
     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
 
@@ -1214,6 +1237,10 @@ dhcp_rebind(struct netif *netif)
 #if LWIP_NETIF_HOSTNAME
     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
 #endif /* LWIP_NETIF_HOSTNAME */
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 
     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_REBINDING, msg_out, DHCP_DISCOVER, &options_out_len);
     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
@@ -1271,6 +1298,10 @@ dhcp_reboot(struct netif *netif)
 #if LWIP_NETIF_HOSTNAME
     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
 #endif /* LWIP_NETIF_HOSTNAME */
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 
     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_REBOOTING, msg_out, DHCP_REQUEST, &options_out_len);
     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
@@ -1339,6 +1370,10 @@ dhcp_release_and_stop(struct netif *netif)
       struct dhcp_msg *msg_out = (struct dhcp_msg *)p_out->payload;
       options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_SERVER_ID, 4);
       options_out_len = dhcp_option_long(options_out_len, msg_out->options, lwip_ntohl(ip4_addr_get_u32(ip_2_ip4(&server_ip_addr))));
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+    options_out_len = dhcp_option_client_identifier(options_out_len, msg_out->options, netif);
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 
       LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, dhcp->state, msg_out, DHCP_RELEASE, &options_out_len);
       dhcp_option_trailer(options_out_len, msg_out->options, p_out);
@@ -1475,6 +1510,20 @@ dhcp_option_hostname(u16_t options_out_len, u8_t *options, struct netif *netif)
   return options_out_len;
 }
 #endif /* LWIP_NETIF_HOSTNAME */
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+static u16_t
+dhcp_option_client_identifier(u16_t options_out_len, u8_t *options, struct netif *netif)
+{
+  size_t i;
+  options_out_len = dhcp_option(options_out_len, options, DHCP_OPTION_CLIENT_ID, DHCP_OPTION_CLIENT_ID_MAC_LEN);
+  options_out_len = dhcp_option_byte(options_out_len, options, DHCP_OPTION_CLIENT_ID_MAC);
+  for (i = 0; i < netif->hwaddr_len; i++) {
+    options_out_len = dhcp_option_byte(options_out_len, options, netif->hwaddr[i]);
+  }
+  return options_out_len;
+}
+#endif /* LWIP_DHCP_OPTION_CLIENT_IDENTIFIER */
 
 /**
  * Extract the DHCP message and the DHCP options.

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -970,6 +970,16 @@
  * @}
  */
 
+/**
+ * LWIP_DHCP_OPTION_CLIENT_IDENTIFIER > 0: Send client identifier option with dhcp requests
+ */
+#if !defined LWIP_DHCP_OPTION_CLIENT_IDENTIFIER || defined __DOXYGEN__
+#define LWIP_DHCP_OPTION_CLIENT_IDENTIFIER      0
+#endif
+/**
+ * @}
+ */
+
 /*
    ------------------------------------
    ---------- AUTOIP options ----------

--- a/src/include/lwip/prot/dhcp.h
+++ b/src/include/lwip/prot/dhcp.h
@@ -160,7 +160,14 @@ typedef enum {
 #define DHCP_OPTION_T1              58 /* T1 renewal time */
 #define DHCP_OPTION_T2              59 /* T2 rebinding time */
 #define DHCP_OPTION_US              60
-#define DHCP_OPTION_CLIENT_ID       61
+
+#if LWIP_DHCP_OPTION_CLIENT_IDENTIFIER
+#define DHCP_OPTION_CLIENT_ID       61 /* RFC 2132 9.14, Client Identifier */
+
+#define DHCP_OPTION_CLIENT_ID_MAC       0x01 /* Ethernet */
+#define DHCP_OPTION_CLIENT_ID_MAC_LEN   7
+#endif
+
 #define DHCP_OPTION_TFTP_SERVERNAME 66
 #define DHCP_OPTION_BOOTFILE        67
 
@@ -169,6 +176,7 @@ typedef enum {
 #define DHCP_OVERLOAD_FILE          1
 #define DHCP_OVERLOAD_SNAME         2
 #define DHCP_OVERLOAD_SNAME_FILE    3
+
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add DHCP option 61. This is used by a lot of DHCP servers in enterprise environment to determine the correctness of the client (whitelisting).

```
Frame 151: 350 bytes on wire (2800 bits), 350 bytes captured (2800 bits) on interface enp6s0, id 0
    Interface id: 0 (enp6s0)
        Interface name: enp6s0
    Encapsulation type: Ethernet (1)
    Arrival Time: Feb 21, 2022 13:32:00.464284021 CET
    [Time shift for this packet: 0.000000000 seconds]
    Epoch Time: 1645446720.464284021 seconds
    [Time delta from previous captured frame: 60.002995977 seconds]
    [Time delta from previous displayed frame: 60.002995977 seconds]
    [Time since reference or first frame: 4083.246598659 seconds]
    Frame Number: 151
    Frame Length: 350 bytes (2800 bits)
    Capture Length: 350 bytes (2800 bits)
    [Frame is marked: False]
    [Frame is ignored: False]
    [Protocols in frame: eth:ethertype:ip:udp:dhcp]
    [Coloring Rule Name: UDP]
    [Coloring Rule String: udp]
Ethernet II, Src: 7e:13:2a:ca:55:db (7e:13:2a:ca:55:db), Dst: Broadcast (ff:ff:ff:ff:ff:ff)
    Destination: Broadcast (ff:ff:ff:ff:ff:ff)
        Address: Broadcast (ff:ff:ff:ff:ff:ff)
        .... ..1. .... .... .... .... = LG bit: Locally administered address (this is NOT the factory default)
        .... ...1 .... .... .... .... = IG bit: Group address (multicast/broadcast)
    Source: 7e:13:2a:ca:55:db (7e:13:2a:ca:55:db)
        Address: 7e:13:2a:ca:55:db (7e:13:2a:ca:55:db)
        .... ..1. .... .... .... .... = LG bit: Locally administered address (this is NOT the factory default)
        .... ...0 .... .... .... .... = IG bit: Individual address (unicast)
    Type: IPv4 (0x0800)
Internet Protocol Version 4, Src: 0.0.0.0, Dst: 255.255.255.255
    0100 .... = Version: 4
    .... 0101 = Header Length: 20 bytes (5)
    Differentiated Services Field: 0x00 (DSCP: CS0, ECN: Not-ECT)
        0000 00.. = Differentiated Services Codepoint: Default (0)
        .... ..00 = Explicit Congestion Notification: Not ECN-Capable Transport (0)
    Total Length: 336
    Identification: 0x0012 (18)
    Flags: 0x00
        0... .... = Reserved bit: Not set
        .0.. .... = Don't fragment: Not set
        ..0. .... = More fragments: Not set
    ...0 0000 0000 0000 = Fragment Offset: 0
    Time to Live: 255
    Protocol: UDP (17)
    Header Checksum: 0xba8b [validation disabled]
    [Header checksum status: Unverified]
    Source Address: 0.0.0.0
    Destination Address: 255.255.255.255
User Datagram Protocol, Src Port: 68, Dst Port: 67
    Source Port: 68
    Destination Port: 67
    Length: 316
    Checksum: 0xe823 [unverified]
    [Checksum Status: Unverified]
    [Stream index: 0]
    [Timestamps]
        [Time since first frame: 4073.201294165 seconds]
        [Time since previous frame: 60.002995977 seconds]
    UDP payload (308 bytes)
Dynamic Host Configuration Protocol (Discover)
    Message type: Boot Request (1)
    Hardware type: Ethernet (0x01)
    Hardware address length: 6
    Hops: 0
    Transaction ID: 0x5851f42d
    Seconds elapsed: 0
    Bootp flags: 0x0000 (Unicast)
        0... .... .... .... = Broadcast flag: Unicast
        .000 0000 0000 0000 = Reserved flags: 0x0000
    Client IP address: 0.0.0.0
    Your (client) IP address: 0.0.0.0
    Next server IP address: 0.0.0.0
    Relay agent IP address: 0.0.0.0
    Client MAC address: 7e:13:2a:ca:55:db (7e:13:2a:ca:55:db)
    Client hardware address padding: 00000000000000000000
    Server host name not given
    Boot file name not given
    Magic cookie: DHCP
    Option: (53) DHCP Message Type (Discover)
        Length: 1
        DHCP: Discover (1)
    Option: (57) Maximum DHCP Message Size
        Length: 2
        Maximum DHCP Message Size: 1500
    Option: (12) Host Name
        Length: 27
        Host Name: MyDeviceRocks55db
    Option: (61) Client identifier
        Length: 7
        Hardware type: Ethernet (0x01)
        Client MAC address: 7e:13:2a:ca:55:db (7e:13:2a:ca:55:db)
    Option: (55) Parameter Request List
        Length: 4
        Parameter Request List Item: (1) Subnet Mask
        Parameter Request List Item: (3) Router
        Parameter Request List Item: (28) Broadcast Address
        Parameter Request List Item: (6) Domain Name Server
    Option: (255) End
        Option End: 255
    Padding: 00000000000000000000000000000000
```