### PR TITLE
makefsdata: extend file type matching with .shtml and .shtm

### DIFF
--- a/src/apps/http/makefsdata/makefsdata
+++ b/src/apps/http/makefsdata/makefsdata
@@ -21,7 +21,7 @@ while($file = <FILES>) {
 	print(HEADER "HTTP/1.0 200 OK\r\n");
     }
     print(HEADER "Server: lwIP/pre-0.6 (http://www.sics.se/~adam/lwip/)\r\n");
-    if($file =~ /\.html$/) {
+    if($file =~ /\.s?html?$/) {
 	print(HEADER "Content-type: text/html\r\n");
     } elsif($file =~ /\.gif$/) {
 	print(HEADER "Content-type: image/gif\r\n");


### PR DESCRIPTION
[Problem]
When using makefsdata perl script to convert shtml files with SSI tags
the shtml files get generated with text/plain content type, making
browsers not render them correctly

[Solution]
Extend the regex to generate text/html content type for any of:
.htm, .html, .shtm, .shtml extensions