### PR TITLE
dhcp: limit number of dns servers we parse to LWIP_DHCP_PROVIDE_DNS_S…

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -1577,7 +1577,7 @@ again:
         /* special case: there might be more than one server */
         LWIP_DHCP_INPUT_ERROR("len %% 4 == 0", len % 4 == 0, return ERR_VAL;);
         /* limit number of DNS servers */
-        decode_len = LWIP_MIN(len, 4 * DNS_MAX_SERVERS);
+        decode_len = LWIP_MIN(len, 4 * LWIP_DHCP_PROVIDE_DNS_SERVERS);
         LWIP_DHCP_INPUT_ERROR("len >= decode_len", len >= decode_len, return ERR_VAL;);
         decode_idx = DHCP_OPTION_IDX_DNS_SERVER;
         break;


### PR DESCRIPTION
Hi,

I met an issue in the following condition:

DNS_MAX_SERVER: 4
LWIP_DHCP_MAX_DNS_SERVERS: 2

While connecting to a certain network i was getting 3 different DNS servers, but the code on the dhcp side tries to parse 4 entries instead of 2:
`
/* limit number of DNS servers */
decode_len = LWIP_MIN(len, 4 * DNS_MAX_SERVERS);
`	
causing an assert at:

`LWIP_ASSERT("check decode_idx", decode_idx >= 0 && decode_idx < DHCP_OPTION_IDX_MAX);`

I think it's correct to use LWIP_DHCP_PROVIDE_DNS_SERVERS instead of DNS_MAX_SERVERS.

Let me know if i'm wrong. Currently i modified it like this to make it work.

Regards.