### PR TITLE
ping_recv doesn't work if LWIP_IPV6 is true

### DIFF
--- a/contrib/apps/ping/ping.c
+++ b/contrib/apps/ping/ping.c
@@ -299,8 +299,8 @@ ping_recv(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr)
   LWIP_UNUSED_ARG(addr);
   LWIP_ASSERT("p != NULL", p != NULL);
 
-  if ((p->tot_len >= (PBUF_IP_HLEN + sizeof(struct icmp_echo_hdr))) &&
-      pbuf_remove_header(p, PBUF_IP_HLEN) == 0) {
+  if ((p->tot_len >= (ip_current_header_tot_len() + sizeof(struct icmp_echo_hdr))) &&
+      pbuf_remove_header(p, ip_current_header_tot_len()) == 0) {
     iecho = (struct icmp_echo_hdr *)p->payload;
 
     if ((iecho->id == PING_ID) && (iecho->seqno == lwip_htons(ping_seq_num))) {
@@ -314,7 +314,7 @@ ping_recv(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr)
       return 1; /* eat the packet */
     }
     /* not eaten, restore original packet */
-    pbuf_add_header(p, PBUF_IP_HLEN);
+    pbuf_add_header(p, ip_current_header_tot_len());
   }
 
   return 0; /* don't eat the packet */


### PR DESCRIPTION
PBUF_IP_HLEN changes size if LWIP_IPV6 is set. Use
ip_current_header_tot_len instead?