### PR TITLE
fixed bug with 'space' being defined unsigned in tcp_write leading to…

### DIFF
--- a/src/core/tcp_out.c
+++ b/src/core/tcp_out.c
@@ -477,7 +477,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u16_t len, u8_t apiflags)
 
   /* Find the tail of the unsent queue. */
   if (pcb->unsent != NULL) {
-    u16_t space;
+    int16_t space;
     u16_t unsent_optlen;
 
     /* @todo: this could be sped up by keeping last_unsent in the pcb */


### PR DESCRIPTION
I have tracked down an issue over on sming where the http server would not respond to requests for files, larger than about more than 2.5k.
Turns out, the declaratio of 'space' in tcp_write is unsigned when it should be, I think, singed. (evidenced by the fact that it's compared to be >0 later on, which makes no sense for a u16_t)