### PR TITLE
dhcp: add support for MUD options (RFC 8520)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -983,6 +983,19 @@
 #if !defined LWIP_DHCP_MUD_URL || defined __DOXYGEN__
 #define LWIP_DHCP_MUD_URL               0
 #endif
+
+/**
+ * LWIP_MUD_URL_STRING: Specifies a URL that points to a Manufacturer Usage Description (MUD)
+ * file describing this device.
+ * This URL will only be emitted via DHCP or DHCPv6 if LWIP_DHCP_MUD_URL or LWIP_DHCP6_MUD_URL are set
+ * to 1, respectively.
+ * The URL MUST start with https://.
+ *
+ * See RFC 8520 for more information.
+ */
+#ifdef __DOXYGEN__
+#define LWIP_MUD_URL_STRING             "https://example.org/mud-file"
+#endif
 /**
  * @}
  */

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -976,6 +976,13 @@
 #if !defined LWIP_DHCP_DISCOVER_ADD_HOSTNAME || defined __DOXYGEN__
 #define LWIP_DHCP_DISCOVER_ADD_HOSTNAME 0
 #endif /* LWIP_DHCP_DISCOVER_ADD_HOSTNAME */
+
+/**
+ * LWIP_DHCP_MUD_URL == 1: Emit Manufacturer Usage Description (MUD) URL (RFC 8520) via DHCP.
+ */
+#if !defined LWIP_DHCP_MUD_URL || defined __DOXYGEN__
+#define LWIP_DHCP_MUD_URL               0
+#endif
 /**
  * @}
  */

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -2791,6 +2791,13 @@
 #if !defined LWIP_DHCP6_MAX_DNS_SERVERS || defined __DOXYGEN__
 #define LWIP_DHCP6_MAX_DNS_SERVERS      DNS_MAX_SERVERS
 #endif
+
+/**
+ * LWIP_DHCP6_MUD_URL == 1: Emit Manufacturer Usage Description (MUD) URL (RFC 8520) via DHCPv6.
+ */
+#if !defined LWIP_DHCP6_MUD_URL || defined __DOXYGEN__
+#define LWIP_DHCP6_MUD_URL              0
+#endif
 /**
  * @}
  */

--- a/src/include/lwip/prot/dhcp.h
+++ b/src/include/lwip/prot/dhcp.h
@@ -164,6 +164,8 @@ typedef enum {
 #define DHCP_OPTION_TFTP_SERVERNAME 66
 #define DHCP_OPTION_BOOTFILE        67
 
+#define DHCP_OPTION_MUD_URL_V4      116 /* RFC 8520 10., MUD URL Option */
+
 /* possible combinations of overloading the file and sname fields with options */
 #define DHCP_OVERLOAD_NONE          0
 #define DHCP_OVERLOAD_FILE          1

--- a/src/include/lwip/prot/dhcp6.h
+++ b/src/include/lwip/prot/dhcp6.h
@@ -129,6 +129,7 @@ typedef enum {
 #define DHCP6_OPTION_DNS_SERVERS    23 /* RFC 3646 */
 #define DHCP6_OPTION_DOMAIN_LIST    24 /* RFC 3646 */
 #define DHCP6_OPTION_SNTP_SERVERS   31 /* RFC 4075 */
+#define DHCP6_OPTION_MUD_URL_V6     112 /* RFC 8520 */
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hi everyone :)

More than a year ago, I submitted a couple of patches (see https://savannah.nongnu.org/patch/?10265) to introduce support for the Manufacturer Usage Description (MUD, [RFC 8520](https://datatracker.ietf.org/doc/html/rfc8520)) to the DHCP(v6) clients.

As I got no response to the patches so far, I wanted to create this PR to potentially increase the chance that the patches get seen and reviewed. As there have been some changes in the upstream repository in the meantime, I rebased my development branch to create a clean diff. After a potential review, I could resubmit the patches over on Savannah. 