### PR TITLE
patch #10345: Implement IPv6 socket options

### DIFF
--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3182,6 +3182,12 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_HOPS) = %d\n",
                                       s, *(u8_t *)optval));
           break;
+        case IPV6_MULTICAST_LOOP:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, u8_t, NETCONN_UDP);
+          *(u8_t *)optval = udp_is_flag_set(sock->conn->pcb.udp, UDP_FLAGS_MULTICAST_LOOP) ? 1 : 0;
+          LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_LOOP) = %d\n",
+                                      s, *(u8_t *)optval));
+          break;
 #endif /* LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
         default:
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, UNIMPL: optname=0x%x, ..)\n",
@@ -3680,6 +3686,14 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
         case IPV6_MULTICAST_HOPS:
           LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, u8_t, NETCONN_UDP);
           udp_set_multicast_ttl(sock->conn->pcb.udp, (u8_t)(*(const u8_t *)optval));
+          break;
+        case IPV6_MULTICAST_LOOP:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, u8_t, NETCONN_UDP);
+          if (*(const u8_t *)optval) {
+            udp_set_flags(sock->conn->pcb.udp, UDP_FLAGS_MULTICAST_LOOP);
+          } else {
+            udp_clear_flags(sock->conn->pcb.udp, UDP_FLAGS_MULTICAST_LOOP);
+          }
           break;
 #endif /* LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
 #if LWIP_IPV6_MLD

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3080,21 +3080,13 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
           break;
 #if LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP
         case IP_MULTICAST_TTL:
-          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, *optlen, u8_t);
-          if (NETCONNTYPE_GROUP(netconn_type(sock->conn)) != NETCONN_UDP) {
-            done_socket(sock);
-            return ENOPROTOOPT;
-          }
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, u8_t, NETCONN_UDP);
           *(u8_t *)optval = udp_get_multicast_ttl(sock->conn->pcb.udp);
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, IP_MULTICAST_TTL) = %d\n",
                                       s, *(int *)optval));
           break;
         case IP_MULTICAST_IF:
-          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, *optlen, struct in_addr);
-          if (NETCONNTYPE_GROUP(netconn_type(sock->conn)) != NETCONN_UDP) {
-            done_socket(sock);
-            return ENOPROTOOPT;
-          }
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, struct in_addr, NETCONN_UDP);
           inet_addr_from_ip4addr((struct in_addr *)optval, udp_get_multicast_netif_addr(sock->conn->pcb.udp));
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, IP_MULTICAST_IF) = 0x%"X32_F"\n",
                                       s, *(u32_t *)optval));

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3083,7 +3083,7 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
           LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, u8_t, NETCONN_UDP);
           *(u8_t *)optval = udp_get_multicast_ttl(sock->conn->pcb.udp);
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, IP_MULTICAST_TTL) = %d\n",
-                                      s, *(int *)optval));
+                                      s, *(u8_t *)optval));
           break;
         case IP_MULTICAST_IF:
           LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, struct in_addr, NETCONN_UDP);
@@ -3179,6 +3179,12 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
           *(int *)optval = udp_get_multicast_netif_index(sock->conn->pcb.udp);
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_IF) = %d\n",
                                       s, *(int *)optval));
+          break;
+        case IPV6_MULTICAST_HOPS:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, u8_t, NETCONN_UDP);
+          *(u8_t *)optval = udp_get_multicast_ttl(sock->conn->pcb.udp);
+          LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_HOPS) = %d\n",
+                                      s, *(u8_t *)optval));
           break;
 #endif /* LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
         default:
@@ -3674,6 +3680,10 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
           udp_set_multicast_netif_index(sock->conn->pcb.udp, (u8_t)(*(int *)optval));
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_IF, ..) -> %d\n",
                                       s, *(int *)optval));
+          break;
+        case IPV6_MULTICAST_HOPS:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, u8_t, NETCONN_UDP);
+          udp_set_multicast_ttl(sock->conn->pcb.udp, (u8_t)(*(const u8_t *)optval));
           break;
 #endif /* LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
 #if LWIP_IPV6_MLD

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3181,6 +3181,14 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_V6ONLY) = %d\n",
                                       s, *(int *)optval));
           break;
+#if LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP
+        case IPV6_MULTICAST_IF:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, int, NETCONN_UDP);
+          *(int *)optval = udp_get_multicast_netif_index(sock->conn->pcb.udp);
+          LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_IF) = %d\n",
+                                      s, *(int *)optval));
+          break;
+#endif /* LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
         default:
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, UNIMPL: optname=0x%x, ..)\n",
                                       s, optname));
@@ -3668,6 +3676,14 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IPV6, IPV6_V6ONLY, ..) -> %d\n",
                                       s, (netconn_get_ipv6only(sock->conn) ? 1 : 0)));
           break;
+#if LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP
+        case IPV6_MULTICAST_IF:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, int, NETCONN_UDP);
+          udp_set_multicast_netif_index(sock->conn->pcb.udp, (u8_t)(*(int *)optval));
+          LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IPV6, IPV6_MULTICAST_IF, ..) -> %d\n",
+                                      s, *(int *)optval));
+          break;
+#endif /* LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
 #if LWIP_IPV6_MLD
         case IPV6_JOIN_GROUP:
         case IPV6_LEAVE_GROUP: {

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3092,14 +3092,10 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
                                       s, *(u32_t *)optval));
           break;
         case IP_MULTICAST_LOOP:
-          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, *optlen, u8_t);
-          if ((sock->conn->pcb.udp->flags & UDP_FLAGS_MULTICAST_LOOP) != 0) {
-            *(u8_t *)optval = 1;
-          } else {
-            *(u8_t *)optval = 0;
-          }
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, *optlen, u8_t, NETCONN_UDP);
+          *(u8_t *)optval = udp_is_flag_set(sock->conn->pcb.udp, UDP_FLAGS_MULTICAST_LOOP) ? 1 : 0;
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, IP_MULTICAST_LOOP) = %d\n",
-                                      s, *(int *)optval));
+                                      s, *(u8_t *)optval));
           break;
 #endif /* LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
         default:

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3169,6 +3169,12 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
     /* Level: IPPROTO_IPV6 */
     case IPPROTO_IPV6:
       switch (optname) {
+        case IPV6_UNICAST_HOPS:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, *optlen, int);
+          *(int *)optval = sock->conn->pcb.ip->ttl;
+          LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IPV6, IPV6_UNICAST_HOPS) = %d\n",
+                                      s, *(int *)optval));
+          break;
         case IPV6_V6ONLY:
           LWIP_SOCKOPT_CHECK_OPTLEN_CONN(sock, *optlen, int);
           *(int *)optval = (netconn_get_ipv6only(sock->conn) ? 1 : 0);
@@ -3646,6 +3652,12 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
     /* Level: IPPROTO_IPV6 */
     case IPPROTO_IPV6:
       switch (optname) {
+        case IPV6_UNICAST_HOPS:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, optlen, int);
+          sock->conn->pcb.ip->ttl = *(int *)optval;
+          LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IPV6, IPV6_UNICAST_HOPS, ...) -> %d\n",
+                                      s, *(int *)optval));
+          break;
         case IPV6_V6ONLY:
           LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, optlen, int);
           if (*(const int *)optval) {

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3541,9 +3541,9 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
         case IP_PKTINFO:
           LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, int, NETCONN_UDP);
           if (*(const int *)optval) {
-            sock->conn->flags |= NETCONN_FLAG_PKTINFO;
+            netconn_set_flags(sock->conn, NETCONN_FLAG_PKTINFO);
           } else {
-            sock->conn->flags &= ~NETCONN_FLAG_PKTINFO;
+            netconn_clear_flags(sock->conn, NETCONN_FLAG_PKTINFO);
           }
           break;
 #endif /* LWIP_NETBUF_RECVINFO */

--- a/src/core/ipv6/ip6_addr.c
+++ b/src/core/ipv6/ip6_addr.c
@@ -57,7 +57,7 @@
 /* used by IP6_ADDR_ANY(6) in ip6_addr.h */
 const ip_addr_t ip6_addr_any = IPADDR6_INIT(0ul, 0ul, 0ul, 0ul);
 
-#define lwip_xchar(i)        ((char)((i) < 10 ? '0' + (i) : 'A' + (i) - 10))
+#define lwip_xchar(i)        ((char)((i) < 10 ? '0' + (i) : 'a' + (i) - 10))
 
 /**
  * Check whether "cp" is a valid ascii representation

--- a/src/core/pbuf.c
+++ b/src/core/pbuf.c
@@ -1343,6 +1343,7 @@ pbuf_clone(pbuf_layer layer, pbuf_type type, struct pbuf *p)
     return NULL;
   }
   err = pbuf_copy(q, p);
+  q->if_idx = p->if_idx;
   LWIP_UNUSED_ARG(err); /* in case of LWIP_NOASSERT */
   LWIP_ASSERT("pbuf_copy failed", err == ERR_OK);
   return q;

--- a/src/include/lwip/api.h
+++ b/src/include/lwip/api.h
@@ -92,6 +92,10 @@ extern "C" {
 #endif /* LWIP_NETBUF_RECVINFO */
 /** A FIN has been received but not passed to the application yet */
 #define NETCONN_FIN_RX_PENDING                0x80
+#if LWIP_NETBUF_RECVINFO
+/** The hop limit will be stored for incoming packets */
+#define NETCONN_FLAG_HOPLIMIT                 0x100
+#endif /* LWIP_NETBUF_RECVINFO */
 
 /* Helpers to process several netconn_types by the same code */
 #define NETCONNTYPE_GROUP(t)         ((t)&0xF0)
@@ -274,7 +278,7 @@ struct netconn {
   s16_t linger;
 #endif /* LWIP_SO_LINGER */
   /** flags holding more netconn-internal state, see NETCONN_FLAG_* defines */
-  u8_t flags;
+  u16_t flags;
 #if LWIP_TCP
   /** TCP: when data passed to netconn_write doesn't fit into the send buffer,
       this temporarily stores the message.
@@ -369,8 +373,8 @@ err_t   netconn_gethostbyname(const char *name, ip_addr_t *addr);
 err_t   netconn_err(struct netconn *conn);
 #define netconn_recv_bufsize(conn)      ((conn)->recv_bufsize)
 
-#define netconn_set_flags(conn, set_flags)     do { (conn)->flags = (u8_t)((conn)->flags |  (set_flags)); } while(0)
-#define netconn_clear_flags(conn, clr_flags)   do { (conn)->flags = (u8_t)((conn)->flags & (u8_t)(~(clr_flags) & 0xff)); } while(0)
+#define netconn_set_flags(conn, set_flags)     do { (conn)->flags = (u16_t)((conn)->flags |  (set_flags)); } while(0)
+#define netconn_clear_flags(conn, clr_flags)   do { (conn)->flags = (u16_t)((conn)->flags & (u16_t)(~(clr_flags) & 0xffff)); } while(0)
 #define netconn_is_flag_set(conn, flag)        (((conn)->flags & (flag)) != 0)
 
 #define netconn_set_callback_arg(conn, arg)   do { (conn)->callback_arg.ptr = (arg); } while(0)

--- a/src/include/lwip/netbuf.h
+++ b/src/include/lwip/netbuf.h
@@ -55,6 +55,8 @@ extern "C" {
 #define NETBUF_FLAG_DESTADDR    0x01
 /** This netbuf includes a checksum */
 #define NETBUF_FLAG_CHKSUM      0x02
+/** This netbuf has hop limit set */
+#define NETBUF_FLAG_HOPLIMIT    0x04
 
 /** "Network buffer" - contains data and addressing info */
 struct netbuf {
@@ -66,6 +68,9 @@ struct netbuf {
   u16_t toport_chksum;
 #if LWIP_NETBUF_RECVINFO
   ip_addr_t toaddr;
+#if LWIP_IPV6
+  u8_t hoplim;
+#endif /* LWIP_IPV6 */
 #endif /* LWIP_NETBUF_RECVINFO */
 #endif /* LWIP_NETBUF_RECVINFO || LWIP_CHECKSUM_ON_COPY */
 };

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -320,6 +320,7 @@ struct linger {
 
 #define IPV6_MULTICAST_IF    17 /* RFC3493: interface for outgoing multicast packets */
 #define IPV6_MULTICAST_HOPS  18 /* RFC3493: hop limit for outgoing multicast packets */
+#define IPV6_MULTICAST_LOOP  19 /* RFC3493: a copy of the packet is looped back for local delivery */
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
 
 #if LWIP_IGMP

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -299,6 +299,8 @@ struct linger {
 #define IPV6_CHECKSUM       7  /* RFC3542: calculate and insert the ICMPv6 checksum for raw sockets. */
 #define IPV6_UNICAST_HOPS   16 /* RFC3493: hop limit in outgoing unicast IPv6 packets */
 #define IPV6_V6ONLY         27 /* RFC3493: boolean control to restrict AF_INET6 sockets to IPv6 communications only. */
+#define IPV6_RECVPKTINFO    49 /* RFC3542: receive ancillary data for packet */
+#define IPV6_PKTINFO        50 /* RFC3542: ancillary data for a packet */
 #endif /* LWIP_IPV6 */
 
 #if LWIP_UDP && LWIP_UDPLITE
@@ -342,6 +344,13 @@ struct in_pktinfo {
   struct in_addr ipi_addr;     /* Destination (from header) address */
 };
 #endif /* LWIP_IPV4 */
+
+#if LWIP_IPV6
+struct in6_pktinfo {
+  struct in6_addr ipi6_addr;
+  int             ipi6_ifindex;
+};
+#endif /* LWIP_IPV6 */
 
 #if LWIP_IPV6_MLD
 /*

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -319,6 +319,7 @@ struct linger {
 #define IP_MULTICAST_LOOP  7
 
 #define IPV6_MULTICAST_IF    17 /* RFC3493: interface for outgoing multicast packets */
+#define IPV6_MULTICAST_HOPS  18 /* RFC3493: hop limit for outgoing multicast packets */
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
 
 #if LWIP_IGMP

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -317,6 +317,8 @@ struct linger {
 #define IP_MULTICAST_TTL   5
 #define IP_MULTICAST_IF    6
 #define IP_MULTICAST_LOOP  7
+
+#define IPV6_MULTICAST_IF    17 /* RFC3493: interface for outgoing multicast packets */
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
 
 #if LWIP_IGMP

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -301,6 +301,8 @@ struct linger {
 #define IPV6_V6ONLY         27 /* RFC3493: boolean control to restrict AF_INET6 sockets to IPv6 communications only. */
 #define IPV6_RECVPKTINFO    49 /* RFC3542: receive ancillary data for packet */
 #define IPV6_PKTINFO        50 /* RFC3542: ancillary data for a packet */
+#define IPV6_RECVHOPLIMIT   51 /* RFC3542: receive hop limit for packet */
+#define IPV6_HOPLIMIT       52 /* RFC3542: ancillary data containing hop limit for packet */
 #endif /* LWIP_IPV6 */
 
 #if LWIP_UDP && LWIP_UDPLITE

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -297,6 +297,7 @@ struct linger {
  * Options for level IPPROTO_IPV6
  */
 #define IPV6_CHECKSUM       7  /* RFC3542: calculate and insert the ICMPv6 checksum for raw sockets. */
+#define IPV6_UNICAST_HOPS   16 /* RFC3493: hop limit in outgoing unicast IPv6 packets */
 #define IPV6_V6ONLY         27 /* RFC3493: boolean control to restrict AF_INET6 sockets to IPv6 communications only. */
 #endif /* LWIP_IPV6 */
 


### PR DESCRIPTION
This series of patches implements the following IPv6 socket options:

- `IPV6_UNICAST_HOPS`
- `IPV6_MULTICAST_IF`
- `IPV6_MULTICAST_HOPS`
- `IPV6_MULTICAST_LOOP`
- `IPV6_RECVPKTINFO`
- `IPV6_RECVHOPLIMIT`

Certain other improvements are made along the way.

Note that some of these patches are based on the work in [patch #9554](https://savannah.nongnu.org/patch/?9554), but reduced to bite-sized pieces.

In skimming through some other open patches it looks like some of this work may be similar to:

- [patch #9977](https://savannah.nongnu.org/patch/?9977) (see also #19)
- [patch #10173](https://savannah.nongnu.org/patch/?10173)