### PR TITLE
Fix netdb.c

### DIFF
--- a/src/api/netdb.c
+++ b/src/api/netdb.c
@@ -40,6 +40,7 @@
 #if LWIP_DNS && LWIP_SOCKET
 
 #include "lwip/err.h"
+#include "lwip/errno.h"
 #include "lwip/mem.h"
 #include "lwip/memp.h"
 #include "lwip/ip_addr.h"

--- a/src/api/netdb.c
+++ b/src/api/netdb.c
@@ -383,7 +383,9 @@ lwip_getaddrinfo(const char *nodename, const char *servname,
     /* set up sockaddr */
     inet6_addr_from_ip6addr(&sa6->sin6_addr, ip_2_ip6(&addr));
     sa6->sin6_family = AF_INET6;
+#if LWIP_SOCKET_HAVE_SA_LEN
     sa6->sin6_len = sizeof(struct sockaddr_in6);
+#endif /* LWIP_SOCKET_HAVE_SA_LEN */
     sa6->sin6_port = lwip_htons((u16_t)port_nr);
     sa6->sin6_scope_id = ip6_addr_zone(ip_2_ip6(&addr));
     ai->ai_family = AF_INET6;
@@ -394,7 +396,9 @@ lwip_getaddrinfo(const char *nodename, const char *servname,
     /* set up sockaddr */
     inet_addr_from_ip4addr(&sa4->sin_addr, ip_2_ip4(&addr));
     sa4->sin_family = AF_INET;
+#if LWIP_SOCKET_HAVE_SA_LEN
     sa4->sin_len = sizeof(struct sockaddr_in);
+#endif /* LWIP_SOCKET_HAVE_SA_LEN */
     sa4->sin_port = lwip_htons((u16_t)port_nr);
     ai->ai_family = AF_INET;
 #endif /* LWIP_IPV4 */


### PR DESCRIPTION
Defines EINVAL and ERANGE are used in the file but not included directly. When I try to use <sys/socket.h> and <arpa/inet.h> as LWIP_SOCKET_EXTERNAL_HEADERS it causes errors with this defines.
Added "lwip/errno.h" to netdb.c includes.

Fields sin6_len and sin_len are always used in the file but not all implementations of sockaddr_in or sockaddr_in6 have this fields (including Linux implementation).
Added #if-check to avoid compilation errors in such cases.