### PR TITLE
snmpv2: fixes on trapOID and mib compiler

### DIFF
--- a/contrib/apps/LwipMibCompiler/LwipMibCompiler/Program.cs
+++ b/contrib/apps/LwipMibCompiler/LwipMibCompiler/Program.cs
@@ -74,7 +74,7 @@ namespace LwipMibCompiler
 				string mibFileName = Path.GetFileNameWithoutExtension(mibFile).ToLowerInvariant();
 				destFile = Path.Combine(destFile, mibFileName + ".c");
 			}
-			
+
 			string destFileExt = Path.GetExtension(destFile);
 			if (!String.IsNullOrEmpty(destFileExt))
 			{
@@ -94,10 +94,10 @@ namespace LwipMibCompiler
 				}
 			}
 
-			
+
 			// read and resolve MIB
 			Console.WriteLine(" Reading MIB file...");
-			
+
 			MibDocument md = new MibDocument(mibFile);
 			MibTypesResolver.ResolveTypes(md.Modules[0]);
 			MibTree mt = new MibTree(md.Modules[0] as MibModule);
@@ -335,7 +335,7 @@ namespace LwipMibCompiler
 					{
 						Console.WriteLine(String.Format("Unsupported BaseType: Module='{0}', Name='{1}'!", mibType.Module, mibType.Name));
 					}
-					
+
 					return null;
 				}
 			}
@@ -353,7 +353,7 @@ namespace LwipMibCompiler
 			}
 			else if (ote.Access == MaxAccess.readCreate)
 			{
-				result.AccessMode = SnmpAccessMode.ReadOnly;
+				result.AccessMode = SnmpAccessMode.ReadWrite;
 			}
 			else if (ignoreAccessibleFlag && (ote.Access == MaxAccess.notAccessible))
 			{
@@ -426,7 +426,7 @@ namespace LwipMibCompiler
 			}
 
 			MibTreeNode rowNode = mibTreeNode.ChildNodes[0];
-			
+
 			ObjectType rot = rowNode.Entity as ObjectType;
 			if (rot != null)
 			{

--- a/src/apps/snmp/snmp_traps.c
+++ b/src/apps/snmp/snmp_traps.c
@@ -256,7 +256,7 @@ snmp_prepare_trap_oid(struct snmp_obj_id *dest_snmp_trap_oid, const struct snmp_
     if (sizeof(dest_snmp_trap_oid->id) >= sizeof(snmpTrapOID)) {
       MEMCPY(&dest_snmp_trap_oid->id, snmpTrapOID , sizeof(snmpTrapOID));
       dest_snmp_trap_oid->len = LWIP_ARRAYSIZE(snmpTrapOID);
-      dest_snmp_trap_oid->id[dest_snmp_trap_oid->len++] = specific_trap + 1;
+      dest_snmp_trap_oid->id[dest_snmp_trap_oid->len++] = generic_trap + 1;
     } else {
       err = ERR_MEM;
     }
@@ -359,8 +359,8 @@ snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg,
                                                        NULL,                            /* *next */
                                                        NULL,                            /* *prev */
                                                        {                                /* oid */
-                                                         8,                             /* oid len */
-                                                         {1, 3, 6, 1, 2, 1, 1, 3}       /* oid for sysUpTime */
+                                                         9,                             /* oid len */
+                                                         {1, 3, 6, 1, 2, 1, 1, 3, 0}       /* oid for sysUpTime.0 */
                                                        },
                                                        SNMP_ASN1_TYPE_TIMETICKS,        /* type */
                                                        sizeof(u32_t),                   /* value_len */
@@ -372,7 +372,7 @@ snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg,
                                                        NULL,                            /* *prev */
                                                        {                                /* oid */
                                                          10,                            /* oid len */
-                                                         {1, 3, 6, 1, 6, 3, 1, 1, 4, 1} /* oid for snmpTrapOID */
+                                                         {1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0} /* oid for snmpTrapOID.0 */
                                                        },
                                                        SNMP_ASN1_TYPE_OBJECT_ID,        /* type */
                                                        0,                               /* value_len */

--- a/src/apps/snmp/snmp_traps.c
+++ b/src/apps/snmp/snmp_traps.c
@@ -371,7 +371,7 @@ snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg,
                                                        NULL,                            /* *next */
                                                        NULL,                            /* *prev */
                                                        {                                /* oid */
-                                                         10,                            /* oid len */
+                                                         11,                            /* oid len */
                                                          {1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0} /* oid for snmpTrapOID.0 */
                                                        },
                                                        SNMP_ASN1_TYPE_OBJECT_ID,        /* type */


### PR DESCRIPTION
Fixed trapOID to send according to rfc3584, also treat read-create object as read-write in LwipMibCompiler C code generation because read-create includes write access according to rfc2578.