### PR TITLE
contrib: fixed c++ compatibility of unix port

### DIFF
--- a/contrib/ports/unix/port/include/arch/cc.h
+++ b/contrib/ports/unix/port/include/arch/cc.h
@@ -52,6 +52,10 @@
 #define LWIP_TIMEVAL_PRIVATE 0
 #include <sys/time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LWIP_ERRNO_INCLUDE <errno.h>
 
 #if defined(LWIP_UNIX_LINUX) || defined(LWIP_UNIX_HURD) || defined(LWIP_UNIX_KFREEBSD)
@@ -85,5 +89,9 @@ typedef struct sio_status_s sio_status_t;
 #define __sio_fd_t_defined
 
 typedef unsigned int sys_prot_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LWIP_ARCH_CC_H */

--- a/contrib/ports/unix/port/include/arch/perf.h
+++ b/contrib/ports/unix/port/include/arch/perf.h
@@ -34,6 +34,10 @@
 
 #include <sys/times.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef PERF
 #define PERF_START  { \
                          unsigned long __c1l, __c1h, __c2l, __c2h; \
@@ -59,5 +63,9 @@ void perf_print(unsigned long c1l, unsigned long c1h,
 void perf_print_times(struct tms *start, struct tms *end, char *key);
 
 void perf_init(char *fname);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LWIP_ARCH_PERF_H */

--- a/contrib/ports/unix/port/include/arch/sys_arch.h
+++ b/contrib/ports/unix/port/include/arch/sys_arch.h
@@ -32,6 +32,10 @@
 #ifndef LWIP_ARCH_SYS_ARCH_H
 #define LWIP_ARCH_SYS_ARCH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SYS_MBOX_NULL NULL
 #define SYS_SEM_NULL  NULL
 
@@ -85,6 +89,10 @@ void sys_lock_tcpip_core(void);
 #define LOCK_TCPIP_CORE()          sys_lock_tcpip_core()
 void sys_unlock_tcpip_core(void);
 #define UNLOCK_TCPIP_CORE()        sys_unlock_tcpip_core()
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* LWIP_ARCH_SYS_ARCH_H */

--- a/contrib/ports/unix/port/include/netif/fifo.h
+++ b/contrib/ports/unix/port/include/netif/fifo.h
@@ -3,6 +3,10 @@
 
 #include "lwip/sys.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** How many bytes in fifo */
 #define FIFOSIZE 2048
 
@@ -49,6 +53,10 @@ void fifoPut(fifo_t * fifo, int fd);
 *	@param 	fifo	pointer to fifo data structure, allocated by the user
 */
 void fifoInit(fifo_t * fifo);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/contrib/ports/unix/port/include/netif/list.h
+++ b/contrib/ports/unix/port/include/netif/list.h
@@ -2,6 +2,10 @@
 #ifndef LWIP_LIST_H
 #define LWIP_LIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct elem;
 
 struct list {
@@ -22,5 +26,9 @@ int list_elems(struct list *list);
 void list_delete(struct list *list);
 int list_remove(struct list *list, void *elem);
 void list_map(struct list *list, void (* func)(void *arg));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/contrib/ports/unix/port/include/netif/pcapif.h
+++ b/contrib/ports/unix/port/include/netif/pcapif.h
@@ -34,6 +34,14 @@
 
 #include "lwip/netif.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 err_t pcapif_init(struct netif *netif);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LWIP_PCAPIF_H */

--- a/contrib/ports/unix/port/include/netif/sio.h
+++ b/contrib/ports/unix/port/include/netif/sio.h
@@ -6,6 +6,10 @@
 #include "netif/fifo.h"
 /*#include "netif/pppif.h"*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct sio_status_s {
 	int fd;
 	fifo_t myfifo;
@@ -55,6 +59,10 @@ void sio_flush( sio_status_t * siostat );
 * @param 	siostat siostatus struct, contains sio instance data, given by sio_open
 */
 void sio_change_baud( sioBaudrates baud, sio_status_t * siostat );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/contrib/ports/unix/port/include/netif/tapif.h
+++ b/contrib/ports/unix/port/include/netif/tapif.h
@@ -34,10 +34,18 @@
 
 #include "lwip/netif.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 err_t tapif_init(struct netif *netif);
 void tapif_poll(struct netif *netif);
 #if NO_SYS
 int tapif_select(struct netif *netif);
 #endif /* NO_SYS */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LWIP_TAPIF_H */

--- a/contrib/ports/unix/port/include/netif/vdeif.h
+++ b/contrib/ports/unix/port/include/netif/vdeif.h
@@ -34,10 +34,18 @@
 
 #include "lwip/netif.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 err_t vdeif_init(struct netif *netif);
 void vdeif_poll(struct netif *netif);
 #if NO_SYS
 int vdeif_select(struct netif *netif);
 #endif /* NO_SYS */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LWIP_VDEIF_H */


### PR DESCRIPTION
The header files of the unix port directory (`contrib/ports/unix/*`)  are missing "c++ guards".
I added the default "guards" to all header files: 
```
#ifdef __cplusplus
extern "C" {
#endif

...

#ifdef __cplusplus
}
#endif
```