### PR TITLE
Add option to disable examples apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LWIP_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set (LWIP_DEFINITIONS LWIP_DEBUG=1)
 
-OPTION(LWIP_OPTION_ENABLE_EXAMPLE_APPS "Build example apps on win32/unix/darwin" ON)
+option(LWIP_OPTION_ENABLE_EXAMPLE_APPS "Build example apps on win32/unix/darwin" ON)
 
 if (LWIP_OPTION_ENABLE_EXAMPLE_APPS)
   if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LWIP_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set (LWIP_DEFINITIONS LWIP_DEBUG=1)
 
-option(LWIP_OPTION_ENABLE_EXAMPLE_APPS "Build example apps on win32/unix/darwin" ON)
+option(LWIP_OPTION_ENABLE_EXAMPLE_APPS "Build example apps on win32/linux/darwin" ON)
 
 if (LWIP_OPTION_ENABLE_EXAMPLE_APPS)
   if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,18 @@ set(LWIP_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set (LWIP_DEFINITIONS LWIP_DEBUG=1)
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  add_subdirectory(${LWIP_DIR}/contrib/ports/win32/example_app)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  add_subdirectory(${LWIP_DIR}/contrib/ports/unix/example_app)
+OPTION(LWIP_OPTION_ENABLE_EXAMPLE_APPS "Build example apps on win32/unix/darwin" ON)
+
+if (LWIP_OPTION_ENABLE_EXAMPLE_APPS)
+  if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    add_subdirectory(${LWIP_DIR}/contrib/ports/win32/example_app)
+  elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    add_subdirectory(${LWIP_DIR}/contrib/ports/unix/example_app)
+  else()
+    message(WARNING "Host ${CMAKE_SYSTEM_NAME} is not supported to build example_app")
+  endif()
 else()
-  message(WARNING "Host ${CMAKE_SYSTEM_NAME} is not supported to build example_app")
+  message(STATUS "example_app build disabled")
 endif()
 
 # Source package generation


### PR DESCRIPTION
Not everyone wants the example apps built on these platforms. For our specific use case we have an emulated build for tests and target platform is embedded, in the test environment we don't actually want real sockets. This PR adds an option to disable the example app builds for those that don't want it. The default is to retain the current behavior of building them by default on these platforms. 