### PR TITLE
tcp: Fix TCP timestamps for big-endian systems

### DIFF
--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -1993,17 +1993,17 @@ tcp_parseopt(struct tcp_pcb *pcb)
             return;
           }
           /* TCP timestamp option with valid length */
-          tsval = tcp_get_next_optbyte();
-          tsval |= (tcp_get_next_optbyte() << 8);
+          tsval = (tcp_get_next_optbyte() << 24);
           tsval |= (tcp_get_next_optbyte() << 16);
-          tsval |= (tcp_get_next_optbyte() << 24);
+          tsval |= (tcp_get_next_optbyte() << 8);
+          tsval |= tcp_get_next_optbyte();
           if (flags & TCP_SYN) {
-            pcb->ts_recent = lwip_ntohl(tsval);
+            pcb->ts_recent = tsval;
             /* Enable sending timestamps in every segment now that we know
                the remote host supports it. */
             tcp_set_flags(pcb, TF_TIMESTAMP);
           } else if (TCP_SEQ_BETWEEN(pcb->ts_lastacksent, seqno, seqno + tcplen)) {
-            pcb->ts_recent = lwip_ntohl(tsval);
+            pcb->ts_recent = tsval;
           }
           /* Advance to next option (6 bytes already read) */
           tcp_optidx += LWIP_TCP_OPT_LEN_TS - 6;


### PR DESCRIPTION
Current parsing code is building reverse-order integer, and then calls htonl() to assign right value to "ts_recent" field of pcb.

This works correctly on little-endian machines, where htonl() reverses bytes. However, on big-endian machines, htonl() is no-op, so bytes stay reversed.

This patch fixes it by building non-reversed integer.