### PR TITLE
build: macOS build fix for ported example app

### DIFF
--- a/contrib/ports/unix/port/netif/sio.c
+++ b/contrib/ports/unix/port/netif/sio.c
@@ -35,7 +35,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#if defined(LWIP_UNIX_OPENBSD)
+#if defined(LWIP_UNIX_OPENBSD) || defined(LWIP_UNIX_MACH)
 #include <util.h>
 #endif
 #include <termios.h>

--- a/src/apps/http/makefsdata/makefsdata.c
+++ b/src/apps/http/makefsdata/makefsdata.c
@@ -77,7 +77,7 @@ static int deflate_level; /* default compression level, can be changed via comma
 #define CHDIR(path)                   SetCurrentDirectoryA(path)
 #define CHDIR_SUCCEEDED(ret)          (ret == TRUE)
 
-#elif __linux__
+#elif __linux__ || __APPLE__
 
 #define GETCWD(path, len)             getcwd(path, len)
 #define GETCWD_SUCCEEDED(ret)         (ret != NULL)


### PR DESCRIPTION
Unix-ported example application fails to build in macOS.
I included the relevant changes to add support for macOS.