### PR TITLE
cmake: create dist target if not exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ include(CPack)
 
 # Generate docs before creating source package
 include(src/Filelists.cmake)
-add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-if (TARGET lwipdocs)
-  add_dependencies(dist lwipdocs)
+if (NOT TARGET dist)
+  add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
+  if (TARGET lwipdocs)
+    add_dependencies(dist lwipdocs)
+  endif()
 endif()


### PR DESCRIPTION
I want to use the library as a cmake subproject (`add_subdirectory`) in a larger project. Unfortunately, some other library also defines target `dist`. `dist` is, in fact, so common name, that protecting it with a variable or with `if (NOT TARGET dist)` has become common practice. I would like you to consider merging this as it would reduce maintenance overhead on my and possibly others side. Thanks