### PR TITLE
Change if statements in autoip.c to fix compiler warnings

### DIFF
--- a/src/core/ipv4/autoip.c
+++ b/src/core/ipv4/autoip.c
@@ -303,15 +303,13 @@ autoip_network_changed_link_up(struct netif *netif)
   struct autoip *autoip = netif_autoip_data(netif);
 
   if (autoip && (autoip->state != AUTOIP_STATE_OFF)) {
-    #ifdef LWIP_DHCP_COOP
-    #if !LWIP_DHCP_COOP
+#if !LWIP_DHCP_AUTOIP_COOP
         LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE,
                 ("autoip_network_changed_link_up(): start acd\n"));
         autoip->state = AUTOIP_STATE_CHECKING;
         /* Start acd check again for the last used address */
         acd_start(netif, &autoip->acd, autoip->llipaddr);
-    #endif
-    #endif
+#endif
   }
 }
 
@@ -328,13 +326,11 @@ autoip_network_changed_link_down(struct netif *netif)
   struct autoip *autoip = netif_autoip_data(netif);
 
   if (autoip && (autoip->state != AUTOIP_STATE_OFF)) {
-    #ifdef LWIP_DHCP_AUTOIP_COOP
-    #if LWIP_DHCP_AUTOIP_COOP
+#if LWIP_DHCP_AUTOIP_COOP
         LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE,
                 ("autoip_network_changed_link_down(): stop autoip\n"));
         autoip_stop(netif);
-    #endif
-    #endif
+#endif
   }
 }
 

--- a/src/core/ipv4/autoip.c
+++ b/src/core/ipv4/autoip.c
@@ -302,12 +302,16 @@ autoip_network_changed_link_up(struct netif *netif)
 {
   struct autoip *autoip = netif_autoip_data(netif);
 
-  if (autoip && (autoip->state != AUTOIP_STATE_OFF) && !LWIP_DHCP_AUTOIP_COOP) {
-    LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE,
+  if (autoip && (autoip->state != AUTOIP_STATE_OFF)) {
+    #ifdef LWIP_DHCP_COOP
+    #if !LWIP_DHCP_COOP
+        LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE,
                 ("autoip_network_changed_link_up(): start acd\n"));
-    autoip->state = AUTOIP_STATE_CHECKING;
-    /* Start acd check again for the last used address */
-    acd_start(netif, &autoip->acd, autoip->llipaddr);
+        autoip->state = AUTOIP_STATE_CHECKING;
+        /* Start acd check again for the last used address */
+        acd_start(netif, &autoip->acd, autoip->llipaddr);
+    #endif
+    #endif
   }
 }
 
@@ -323,10 +327,14 @@ autoip_network_changed_link_down(struct netif *netif)
 {
   struct autoip *autoip = netif_autoip_data(netif);
 
-  if (autoip && (autoip->state != AUTOIP_STATE_OFF) && LWIP_DHCP_AUTOIP_COOP) {
-    LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE,
+  if (autoip && (autoip->state != AUTOIP_STATE_OFF)) {
+    #ifdef LWIP_DHCP_AUTOIP_COOP
+    #if LWIP_DHCP_AUTOIP_COOP
+        LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE,
                 ("autoip_network_changed_link_down(): stop autoip\n"));
-    autoip_stop(netif);
+        autoip_stop(netif);
+    #endif
+    #endif
   }
 }
 


### PR DESCRIPTION
Got warnings about unused code when tried to build example app with clang-14 so I moved options checks to preprocessor if statements