### PR TITLE
ARP: add more memory efficient way of handling arp requests

### DIFF
--- a/src/core/ipv4/etharp.c
+++ b/src/core/ipv4/etharp.c
@@ -733,22 +733,16 @@ etharp_input(struct pbuf *p, struct netif *netif
                    &hdr->shwaddr, &sipaddr,
                    ARP_REPLY);
 #else
+        /* swapping addresses here so we don't need need to call any other functions or waste memory
+         * to create header for response packet */
         struct eth_hdr *ethhdr;
         u16_t eth_type_be;
-
-
-	      hdr->opcode = lwip_htons(ARP_REPLY);
-	      Swap(hdr->shwaddr, hdr->dhwaddr);
-	      Swap(hdr->sipaddr, hdr->dipaddr);
-	      SMEMCPY(&hdr->shwaddr, (struct eth_addr *)netif->hwaddr, ETH_HWADDR_LEN);
-
-
-
-
+        hdr->opcode = lwip_htons(ARP_REPLY);
+        Swap(hdr->shwaddr, hdr->dhwaddr);
+        Swap(hdr->sipaddr, hdr->dipaddr);
+        SMEMCPY(&hdr->shwaddr, (struct eth_addr *)netif->hwaddr, ETH_HWADDR_LEN);
         ethhdr = (struct eth_hdr *)p->payload;
-
         eth_type_be = lwip_htons(ETHTYPE_ARP);
-
 
 #if ETHARP_SUPPORT_VLAN && (defined(LWIP_HOOK_VLAN_SET) || LWIP_VLAN_PCP)
         s32_t vlan_prio_vid;
@@ -773,7 +767,6 @@ etharp_input(struct pbuf *p, struct netif *netif
         }
 #endif /* ETHARP_SUPPORT_VLAN && (defined(LWIP_HOOK_VLAN_SET) || LWIP_VLAN_PCP) */
 
-
         LWIP_ASSERT_CORE_LOCKED();
 
         ethhdr = (struct eth_hdr *)p->payload;
@@ -797,7 +790,6 @@ etharp_input(struct pbuf *p, struct netif *netif
               ("ethernet_output: sending packet %p\n", (void *)p));
 
         netif->linkoutput(netif, p);
-
 
         ETHARP_STATS_INC(etharp.xmit);
 #endif /* !LWIP_ARP_REUSE_MEMORY */

--- a/src/include/lwip/etharp.h
+++ b/src/include/lwip/etharp.h
@@ -98,7 +98,11 @@ err_t etharp_add_static_entry(const ip4_addr_t *ipaddr, struct eth_addr *ethaddr
 err_t etharp_remove_static_entry(const ip4_addr_t *ipaddr);
 #endif /* ETHARP_SUPPORT_STATIC_ENTRIES */
 
-void etharp_input(struct pbuf *p, struct netif *netif);
+void etharp_input(struct pbuf *p, struct netif *netif
+#if LWIP_ARP_REUSE_MEMORY
+, size_t header_size_decrement
+#endif
+);
 
 #ifdef __cplusplus
 }

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -731,6 +731,16 @@
 #if !defined ETHARP_TABLE_MATCH_NETIF || defined __DOXYGEN__
 #define ETHARP_TABLE_MATCH_NETIF        !LWIP_SINGLE_NETIF
 #endif
+
+/** LWIP_ARP_REUSE_MEMORY==1: Reuse pbuf used for arp request to send an
+ * arp reply as described in RFC 826.
+ * If disabled, new pbuf will be allocated and all required data from request
+ * packet will be copied with SMEMCPY (better if you want to separate layers
+ * but worse in terms of memory usage)
+ */
+#if !defined LWIP_ARP_REUSE_MEMORY || defined __DOXYGEN__
+#define LWIP_ARP_REUSE_MEMORY           1
+#endif
 /**
  * @}
  */

--- a/src/netif/ethernet.c
+++ b/src/netif/ethernet.c
@@ -192,6 +192,7 @@ ethernet_input(struct pbuf *p, struct netif *netif)
         goto free_and_return;
       }
       /* skip Ethernet header (min. size checked above) */
+#if !LWIP_ARP_REUSE_MEMORY
       if (pbuf_remove_header(p, next_hdr_offset)) {
         LWIP_DEBUGF(ETHARP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_WARNING,
                     ("ethernet_input: ARP response packet dropped, too short (%"U16_F"/%"U16_F")\n",
@@ -204,6 +205,9 @@ ethernet_input(struct pbuf *p, struct netif *netif)
         /* pass p to ARP module */
         etharp_input(p, netif);
       }
+#else
+      etharp_input(p, netif, next_hdr_offset);
+#endif /* !LWIP_ARP_REUSE_MEMORY  */
       break;
 #endif /* LWIP_IPV4 && LWIP_ARP */
 #if PPPOE_SUPPORT


### PR DESCRIPTION
Due to structure of arp request and reply answer it is possible to save some memory and use same pbuf for reply as was used in request. I have rewritten etharp_input function and added LWIP_ARP_REUSE_MEMORY macro to opts so it is still possible to use the old version
Description from opts.h:
```
/** LWIP_ARP_REUSE_MEMORY==1: Reuse pbuf used for arp request to send an
 * arp reply as described in RFC 826.
 * If disabled, new pbuf will be allocated and all required data from request
 * packet will be copied with SMEMCPY (better if you want to separate layers
 * but worse in terms of memory usage)
 */
```