### PR TITLE
Fix dangling pointer

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -7,6 +7,7 @@ with newer versions.
 (git master)
 
   * [Enter new changes just after this line - do not remove this line]
+  * Fixed bug with dangling pointer in snmp_traps.c
   * The eth_addr_cmp and ip_addr_cmp set of functions have been renamed to eth_addr_eq, ip_addr_eq
     and so on, since they return non-zero on equality. Macros for the old names exist.
   * The sio_write function used by PPP now takes the data argument as const.
@@ -66,7 +67,7 @@ with newer versions.
   ++ Application changes:
 
   * UDP does NOT receive multicast traffic from ALL netifs on an UDP PCB bound to a specific
-    netif any more. Users need to bind to IP_ADDR_ANY to receive multicast traffic and compare 
+    netif any more. Users need to bind to IP_ADDR_ANY to receive multicast traffic and compare
     ip_current_netif() to the desired netif for every packet.
     See bug #49662 for an explanation.
 
@@ -94,7 +95,7 @@ with newer versions.
   ++ Port changes
 
   +++ new files:
-    * MANY new and moved files! 
+    * MANY new and moved files!
     * Added src/Filelists.mk for use in Makefile projects
     * Continued moving stack-internal parts from abc.h to abc_priv.h in sub-folder "priv"
       to let abc.h only contain the actual application programmer's API
@@ -107,10 +108,10 @@ with newer versions.
       instead of using one per netconn (these semaphores are used even with core locking
       enabled as some longer lasting functions like big writes still need to delay)
     * Added generalized abstraction for itoa(), strnicmp(), stricmp() and strnstr()
-      in def.h (to be overridden in cc.h) instead of config 
+      in def.h (to be overridden in cc.h) instead of config
       options for netbiosns, httpd, dns, etc. ...
     * New abstraction for hton* and ntoh* functions in def.h.
-      To override them, use the following in cc.h: 
+      To override them, use the following in cc.h:
       #define lwip_htons(x) <your_htons>
       #define lwip_htonl(x) <your_htonl>
 
@@ -190,7 +191,7 @@ with newer versions.
 
     * Moved stack-internal parts of tcp.h to tcp_impl.h, tcp.h now only contains
       the actual application programmer's API
-  
+
     * Separated timer implementation from sys.h/.c, moved to timers.h/.c;
       Added timer implementation for NO_SYS==1, set NO_SYS_NO_TIMERS==1 if you
       still want to use your own timer implementation for NO_SYS==0 (as before).
@@ -264,7 +265,7 @@ with newer versions.
     off any more, if this is set to 0, only one packet (the most recent one) is
     queued (like demanded by RFC 1122).
 
-  
+
   ++ Major bugfixes/improvements
 
   * Implemented tcp_shutdown() to only shut down one end of a connection

--- a/src/apps/snmp/snmp_traps.c
+++ b/src/apps/snmp/snmp_traps.c
@@ -343,6 +343,7 @@ snmp_send_msg(struct snmp_msg_trap *trap_msg, struct snmp_varbind *varbinds, u16
  * and .iso.org.dod.internet.private.enterprises.yourenterprise
  * (sysObjectID) for specific traps.
  */
+ struct snmp_varbind snmp_copy;
 static err_t
 snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg, const struct snmp_obj_id *eoid, s32_t generic_trap, s32_t specific_trap, struct snmp_varbind *varbinds)
 {
@@ -398,7 +399,8 @@ snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg,
       snmp_v2_special_varbinds[1].value = snmp_trap_oid.id;
       if (varbinds != NULL) {
         original_prev = varbinds->prev;
-        varbinds->prev = &snmp_v2_special_varbinds[1];
+        memcpy(&snmp_copy, &snmp_v2_special_varbinds[1], sizeof(snmp_v2_special_varbinds[1]));
+        varbinds->prev = &snmp_copy;
       }
       varbinds = snmp_v2_special_varbinds;  /* After inserting two varbinds at the beginning of the list, make sure that pointer is pointing to the first element  */
     }


### PR DESCRIPTION
- Fix dangling pointer in src/apps/snmp/snmp_traps.c
- Now example_app is built by gcc-13 and gcc-14