### PR TITLE
Fix ip4 loopback when LWIP_SINGLE_NETIF si used

### DIFF
--- a/src/core/ipv4/ip4.c
+++ b/src/core/ipv4/ip4.c
@@ -211,6 +211,19 @@ ip4_route(const ip4_addr_t *dest)
     return netif;
   }
 #endif
+
+#else
+#if LWIP_NETIF_LOOPBACK
+  /* in single netif mode, loopback traffic should be passed through default netif (if defined and up) */
+  if (ip4_addr_isloopback(dest)) {
+    /* don't check for link on loopback traffic */
+    if ((netif_default != NULL) && netif_is_up(netif_default)) {
+      return netif_default;
+    }
+    return NULL;
+  }
+#endif /* LWIP_NETIF_LOOPBACK */
+
 #endif /* !LWIP_SINGLE_NETIF */
 
   if ((netif_default == NULL) || !netif_is_up(netif_default) || !netif_is_link_up(netif_default) ||


### PR DESCRIPTION
When LWIP_SINGLE_NETIF is used, LWIP_NETIF_LOOPBACK case is not managed at all in the ip4_route() function. Consequently any ip4 loopback packet is rejected.

This adds the required code to fix this.