### PR TITLE
Support FreeBSD in the default configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (LWIP_DEFINITIONS LWIP_DEBUG=1)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   add_subdirectory(${LWIP_DIR}/contrib/ports/win32/example_app)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
   add_subdirectory(${LWIP_DIR}/contrib/ports/unix/example_app)
 else()
   message(WARNING "Host ${CMAKE_SYSTEM_NAME} is not supported to build example_app")

--- a/contrib/ports/unix/port/include/arch/cc.h
+++ b/contrib/ports/unix/port/include/arch/cc.h
@@ -41,6 +41,8 @@
 #define LWIP_UNIX_MACH
 #elif defined __OpenBSD__
 #define LWIP_UNIX_OPENBSD
+#elif defined __FreeBSD__
+#define LWIP_UNIX_FREEBSD
 #elif defined __FreeBSD_kernel__ && __GLIBC__
 #define LWIP_UNIX_KFREEBSD
 #elif defined __CYGWIN__

--- a/contrib/ports/unix/port/netif/sio.c
+++ b/contrib/ports/unix/port/netif/sio.c
@@ -1,7 +1,10 @@
 /* Author: Magnus Ivarsson <magnus.ivarsson@volvo.com> */
 
 /* to get rid of implicit function declarations */
+#ifndef __FreeBSD__
+/* defining this on FreeBSD hides non-standard defines that sio.c depends on */
 #define _XOPEN_SOURCE 600
+#endif
 #define _GNU_SOURCE
 
 /* build with Darwin C extensions not part of POSIX, i.e. FASYNC, SIGIO.
@@ -37,6 +40,8 @@
 #include <stdio.h>
 #if defined(LWIP_UNIX_OPENBSD) || defined(LWIP_UNIX_MACH)
 #include <util.h>
+#elif defined(LWIP_UNIX_FREEBSD)
+#include <libutil.h>
 #endif
 #include <termios.h>
 #include <stdio.h>


### PR DESCRIPTION
FreeBSD support is basically just very small changes related to some different includes and one define to not hide non-standard defines like B115200.