### PR TITLE
Support Server Name Indication & fix handshake

### DIFF
--- a/src/apps/altcp_tls/altcp_tls_mbedtls.c
+++ b/src/apps/altcp_tls/altcp_tls_mbedtls.c
@@ -1293,6 +1293,8 @@ altcp_mbedtls_bio_send(void *ctx, const unsigned char *dataptr, size_t size)
   while (size_left) {
     u16_t write_len = (u16_t)LWIP_MIN(size_left, 0xFFFF);
     err_t err = altcp_write(conn->inner_conn, (const void *)dataptr, write_len, apiflags);
+    /* try to send data... */
+    altcp_output(conn->inner_conn);
     if (err == ERR_OK) {
       written += write_len;
       size_left -= write_len;

--- a/src/include/lwip/altcp_tls.h
+++ b/src/include/lwip/altcp_tls.h
@@ -92,7 +92,7 @@ struct altcp_tls_config *altcp_tls_create_config_server_privkey_cert(const u8_t 
 /** @ingroup altcp_tls
  * Create an ALTCP_TLS client configuration handle
  */
-struct altcp_tls_config *altcp_tls_create_config_client(const u8_t *cert, size_t cert_len);
+struct altcp_tls_config *altcp_tls_create_config_client(const u8_t *cert, size_t cert_len, char *host);
 
 /** @ingroup altcp_tls
  * Create an ALTCP_TLS client configuration handle with two-way server/client authentication


### PR DESCRIPTION
While adding `https://` support to U-Boot, several issues were found while using http client app from lwip with SSL support from mbedtls. Further details are in the commit messages.