### PR TITLE
fix: lwip: when a DHCP lease is obtained, stop autoip to avoid that it overwrites the IP address after conflict resolution

### DIFF
--- a/src/core/ipv4/autoip.c
+++ b/src/core/ipv4/autoip.c
@@ -343,6 +343,11 @@ autoip_stop(struct netif *netif)
 
   LWIP_ASSERT_CORE_LOCKED();
   if (autoip != NULL) {
+    /* Stop and remove acd */
+    if (autoip->state != AUTOIP_STATE_OFF) {
+        acd_stop(&autoip->acd);
+        acd_remove(netif, &autoip->acd);
+    }
     autoip->state = AUTOIP_STATE_OFF;
     if (ip4_addr_islinklocal(netif_ip4_addr(netif))) {
       netif_set_addr(netif, IP4_ADDR_ANY4, IP4_ADDR_ANY4, IP4_ADDR_ANY4);

--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -1394,6 +1394,11 @@ dhcp_release_and_stop(struct netif *netif)
     dhcp_dec_pcb_refcount(); /* free DHCP PCB if not needed any more */
     dhcp->pcb_allocated = 0;
   }
+
+#if LWIP_DHCP_AUTOIP_COOP
+  /* If autoip was started, stop it to avoid that it sets an ip address after conflict resolution */
+  autoip_stop(netif);
+#endif /* LWIP_DHCP_AUTOIP_COOP */
 }
 
 /**

--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -1143,6 +1143,11 @@ dhcp_bind(struct netif *netif)
      to ensure the callback can use dhcp_supplied_address() */
   dhcp_set_state(dhcp, DHCP_STATE_BOUND);
 
+#if LWIP_DHCP_AUTOIP_COOP
+  /* If autoip was started, stop it to avoid that it sets an ip address after conflict resolution */
+  autoip_stop(netif);
+#endif /* LWIP_DHCP_AUTOIP_COOP */
+
   netif_set_addr(netif, &dhcp->offered_ip_addr, &sn_mask, &gw_addr);
   /* interface is used by routing now that an address is set */
 }


### PR DESCRIPTION
## Issue:
When a DHCP lease cannot be obtained, after several retries AutoIP is started, and a new attempt at getting a DHCP lease is made. Simultaneously, AutoIP selects an IP address and performs address conflict detection on that IP address. If the new attempt to get a DHCP lease is successful before ACD finishes, then that IP address is overwritten by the AutoIP address once ACD finishes.

## Fix:
* autoip_stop now invokes acd_stop and acd_remove to properly clean up the administration in acd that was created by autoip_start
* dhcp_bind now invokes autoip_stop so that autoip does not overwrite the IP address obtained by DHCP
* dhcp_release_and_stop now invokes autoip_stop for similar reasons