### PR TITLE
Fixed assertion checking wrong ptr

### DIFF
--- a/src/core/mem.c
+++ b/src/core/mem.c
@@ -741,7 +741,7 @@ mem_trim(void *rmem, mem_size_t new_size)
   if (mem2->used == 0) {
     /* The next struct is unused, we can simply move it at little */
     mem_size_t next;
-    LWIP_ASSERT("invalid next ptr", mem->next != MEM_SIZE_ALIGNED);
+    LWIP_ASSERT("invalid next ptr", mem2->next != MEM_SIZE_ALIGNED);
     /* remember the old next pointer */
     next = mem2->next;
     /* create new struct mem which is moved directly after the shrunk mem */


### PR DESCRIPTION
I've been hit with this assertion when using lwip in esphome (libretiny fork) with assertions enabled.

```
ASSERT "invalid next ptr" - /config/.esphome/platformio/packages/library-lwip@src-c718385076ab23087e1f617d7cb3e11a/src/core/mem.c:790
```

I don't fully grasp what's happening here, apart that its some memory chunks optimizations/defragmentation stuff. But I "smell" the assertion checks the wrong pointer. This whole code block it seems to be mostly about mem2, also mem->next is reassigned anyway in the line 755...

It seems to be a very rare case (when we're at the end of heap, correct?), so I recon nobody has yet found this.