### PR TITLE
fix: bit shifting for 64bit bridge port mask

### DIFF
--- a/src/netif/bridgeif.c
+++ b/src/netif/bridgeif.c
@@ -355,7 +355,7 @@ bridgeif_input(struct pbuf *p, struct netif *netif)
     /* group address -> flood + cpu? */
     dstports = bridgeif_find_dst_ports(br, dst);
     bridgeif_send_to_ports(br, p, dstports);
-    if (dstports & (1 << BRIDGEIF_MAX_PORTS)) {
+    if (dstports & ((bridgeif_portmask_t)1 << BRIDGEIF_MAX_PORTS)) {
       /* we pass the reference to ->input or have to free it */
       LWIP_DEBUGF(BRIDGEIF_FW_DEBUG, ("br -> input(%p)\n", (void *)p));
       if (br->netif->input(p, br->netif) != ERR_OK) {


### PR DESCRIPTION
## Problem

During bridge input processing, there is conditional logic to check if the bridge interface itself should receive the packet (ie. forward to CPU). The existing bitwise logic fails when `BRIDGEIF_MAX_PORTS` >= 32 because the literal `1` is implicitly a 32-bit integer. When shifting this value by `BRIDGEIF_MAX_PORTS` bits (which can be up to 63), it triggers undefined behaviour due to the shift count exceeding the width of the type.

## Fix

Explicitly cast `1` to `bridgeif_portmask_t` to ensure that the shift operation is performed on a 64-bit value when necessary. This works because when `BRIDGEIF_MAX_PORTS >= 32`, `bridgeif_portmask_t` is defined as a `u64_t` type:
https://github.com/lwip-tcpip/lwip/blob/554e104095a25a0e6585385c6775c5534efa4cde/src/include/netif/bridgeif.h#L51-L61