### PR TITLE
autoip: Choose next address after rate limit

### DIFF
--- a/src/core/ipv4/autoip.c
+++ b/src/core/ipv4/autoip.c
@@ -223,9 +223,10 @@ autoip_conflict_callback(struct netif *netif, acd_callback_enum_t state)
       autoip_restart(netif);
       break;
     case ACD_DECLINE:
-      /* "delete" conflicting address so a new one will be selected in
-       * autoip_start() */
+      /* "delete" conflicting address and increment tried addr so a new one
+       * will be selected in autoip_start() */
       ip4_addr_set_any(&autoip->llipaddr);
+      autoip->tried_llipaddr++;
       autoip_stop(netif);
       break;
       default:


### PR DESCRIPTION
# Fix: AutoIP selects a new address after rate limiting

## Issue
After hitting MAX_CONFLICTS (10), AutoIP enters rate limiting mode for 60 seconds. After this timeout, it tries to acquire an IP address again, but it incorrectly reuses the same address that previously had conflicts.

This causes devices to fail Bonjour Conformance Tests for rate limiting, as they should try different addresses after timeouts.

## Root Cause

In lwIP pre-2.2.0, address conflict detection was handled directly in autoip.c, where `tried_llipaddr` was incremented in `autoip_restart()`:

https://github.com/lwip-tcpip/lwip/blob/6ca936f6b588cee702c638eee75c2436e6cf75de/src/core/ipv4/autoip.c#L125-L130

When ACD was extracted into a separate module in 2.2.0, this increment was missing for the rate-limiting path in the callback handler. The `ACD_DECLINE` case cleared the address but didn't increment the counter.

## Fix
The patch adds one line to increment the `tried_llipaddr` counter in the `ACD_DECLINE` case, ensuring that after rate limiting, a new address is tried rather than the same one.

## Testing
With this patch, devices pass the Bonjour Conformance Test for rate limiting.