### PR TITLE
Fix: ignore loopback NA during IPv6 DAD (RFC 4862, 5.4.3)

### DIFF
--- a/src/core/ipv6/nd6.c
+++ b/src/core/ipv6/nd6.c
@@ -353,6 +353,7 @@ nd6_input(struct pbuf *p, struct netif *inp)
       for (i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
         if (!ip6_addr_isinvalid(netif_ip6_addr_state(inp, i)) &&
             !ip6_addr_isduplicated(netif_ip6_addr_state(inp, i)) &&
+            !ip6_addr_eq(ip6_current_src_addr(), netif_ip6_addr(inp, i)) &&
             ip6_addr_eq(&target_address, netif_ip6_addr(inp, i))) {
           /* We are using a duplicate address. */
           nd6_duplicate_addr_detected(inp, i);


### PR DESCRIPTION
This PR addresses an edge case in Duplicate Address Detection (DAD) 
where a node receives its own Neighbor Advertisement (NA) message 
(broadcast via ff02::1) and mistakenly considers it as evidence of 
address duplication, resulting in the unintended removal of its 
link-local address.

According to RFC 4862 Section 5.4.3, such loopbacked messages must 
not be interpreted as a sign of address duplication.

This patch adds a check to ensure that the source address of the 
incoming NA does not match the node’s own address
 