### PR TITLE
tftp: bind to TFTP port only when in server mode

### DIFF
--- a/src/apps/tftp/tftp.c
+++ b/src/apps/tftp/tftp.c
@@ -454,10 +454,12 @@ tftp_init_common(u8_t mode, const struct tftp_context *ctx)
     return ERR_MEM;
   }
 
-  ret = udp_bind(pcb, IP_ANY_TYPE, TFTP_PORT);
-  if (ret != ERR_OK) {
-    udp_remove(pcb);
-    return ret;
+  if (mode & LWIP_TFTP_MODE_SERVER) {
+    ret = udp_bind(pcb, IP_ANY_TYPE, TFTP_PORT);
+    if (ret != ERR_OK) {
+      udp_remove(pcb);
+      return ret;
+    }
   }
 
   tftp_state.handle    = NULL;


### PR DESCRIPTION
The TFTP app should not bind to the TFTP server port when configured as a client. Instead, the local port should be chosen from the dynamic range (49152 ~ 65535) so that if the application is stopped and started again, the remote server will not consider the new packets as part of the same context (which would cause an error since a new RRQ would be unexpected).

Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>