### PR TITLE
Fix ip4 frag bug

### DIFF
--- a/src/core/ipv4/ip4_frag.c
+++ b/src/core/ipv4/ip4_frag.c
@@ -849,7 +849,7 @@ ip4_frag(struct pbuf *p, struct netif *netif, const ip4_addr_t *dest)
 #endif /* LWIP_NETIF_TX_SINGLE_PBUF */
 
     /* Correct header */
-    last = (left <= netif->mtu - IP_HLEN);
+	last = (left <= (u16_t)(nfb * 8));
 
     /* Set new offset and MF flag */
     tmp = (IP_OFFMASK & (ofo));

--- a/src/core/ipv4/ip4_frag.c
+++ b/src/core/ipv4/ip4_frag.c
@@ -849,7 +849,7 @@ ip4_frag(struct pbuf *p, struct netif *netif, const ip4_addr_t *dest)
 #endif /* LWIP_NETIF_TX_SINGLE_PBUF */
 
     /* Correct header */
-	last = (left <= (u16_t)(nfb * 8));
+	last = (left <= fragsize);
 
     /* Set new offset and MF flag */
     tmp = (IP_OFFMASK & (ofo));

--- a/src/core/ipv4/ip4_frag.c
+++ b/src/core/ipv4/ip4_frag.c
@@ -849,7 +849,7 @@ ip4_frag(struct pbuf *p, struct netif *netif, const ip4_addr_t *dest)
 #endif /* LWIP_NETIF_TX_SINGLE_PBUF */
 
     /* Correct header */
-	last = (left <= fragsize);
+last = (left <= fragsize);
 
     /* Set new offset and MF flag */
     tmp = (IP_OFFMASK & (ofo));

--- a/src/core/ipv4/ip4_frag.c
+++ b/src/core/ipv4/ip4_frag.c
@@ -849,7 +849,7 @@ ip4_frag(struct pbuf *p, struct netif *netif, const ip4_addr_t *dest)
 #endif /* LWIP_NETIF_TX_SINGLE_PBUF */
 
     /* Correct header */
-last = (left <= fragsize);
+    last = (left <= fragsize);
 
     /* Set new offset and MF flag */
     tmp = (IP_OFFMASK & (ofo));


### PR DESCRIPTION
### Summary
When the MTU is set to a value other than 1500, the IPv4 fragmentation function may not work correctly. As a result, pinging packets of certain lengths may fail.
### Changes
Changed the fragmentation condition from using the interface MTU minus the IP header length to using the actual maximum fragment size as the basis for determining whether fragmentation is needed.
### Rationale
Using MTU - IP header size as a fragmentation condition can lead to incorrect behavior, especially when MTU is changed dynamically or set to non-default values. This change ensures that the fragmentation process uses the correct limit, avoiding oversized fragments and improving reliability across various transport scenarios.
In the current fragmentation logic, the calculations for nfb and fragsize are as follows:
`const u16_t nfb = (u16_t)((netif->mtu - IP_HLEN) / 8);`
`fragsize = LWIP_MIN(left, (u16_t)(nfb * 8));`
Since nfb is a u16_t type variable, the fragsize does not yield the exact value of netif->mtu - IP_HLEN, but instead a slightly smaller value. This slight discrepancy affects the subsequent fragmentation calculations, particularly when the remaining data length is small but still requires further fragmentation, leading to incorrect behavior.
For example, when a 3524-byte packet is fragmented with a 1176-byte fragment size, the second fragment will leave 1180 bytes, which should be further fragmented into 1176 bytes and 4 bytes (at this point, `fragsize ` is 1176, and` netif->mtu - IP_HLEN` is 1180). However, due to the incorrect fragmentation condition (`left < netif->mtu - IP_HLEN`), the second-to-last fragment incorrectly has the last flag set to 1, leading to a fragmentation error.
![image](https://github.com/user-attachments/assets/bd78639f-e90d-4174-9ecc-15f1221a0649)
This fix updates the fragmentation condition to use the actual maximum fragment size rather than `netif->mtu - IP_HLEN`, ensuring that the fragmentation logic correctly handles cases where remaining data still requires further fragmentation.
### Testing
- Environment: Zynq7000 + lwIP 2.2.1 + RTOS
- Method: Used `ping` command to test specific packet sizes (3524 bytes) under different MTU settings.
- MTU settings tested:
  - MTU set to 1200, with original fragmentation logic: `ping` packets of 3524 bytes consistently dropped.
![image](https://github.com/user-attachments/assets/ec644b16-5011-46ef-bea4-d69f333131f2)
  - MTU set to 1200, with modified fragmentation logic: `ping` packets of 3524 bytes no longer dropped, successfully pinged through.
![image](https://github.com/user-attachments/assets/0efa9912-addb-4c74-910c-db3c1308ec7f)
  - MTU restored to 1500, with modified fragmentation logic: No packet loss observed, normal ping behavior.
