### PR TITLE
altcp_tls: set errno to EPERM when handshake fails

### DIFF
--- a/src/apps/altcp_tls/altcp_tls_mbedtls.c
+++ b/src/apps/altcp_tls/altcp_tls_mbedtls.c
@@ -60,6 +60,8 @@
 
 #if LWIP_ALTCP_TLS && LWIP_ALTCP_TLS_MBEDTLS
 
+#include "lwip/errno.h"
+
 #include "lwip/altcp.h"
 #include "lwip/altcp_tls.h"
 #include "lwip/priv/altcp_priv.h"
@@ -299,6 +301,10 @@ altcp_mbedtls_lower_recv_process(struct altcp_pcb *conn, altcp_mbedtls_state_t *
     if (ret != 0) {
       LWIP_DEBUGF(ALTCP_MBEDTLS_DEBUG, ("mbedtls_ssl_handshake failed: %d\n", ret));
       /* handshake failed, connection has to be closed */
+      if (ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) {
+        /* provide a cause for why the connection is closed to the caller */
+        errno = EPERM;
+      }
       if (conn->err) {
         conn->err(conn->arg, ERR_CLSD);
       }


### PR DESCRIPTION
When a TLS client connects to a server and the handshake fails due to certificate validation, no specific error code is returned to the caller. The TCP connection is simply closed. This is not very user-friendly. Instead the client application would probably want to notify the user of the security issue. For that purpose, set errno to EPERM to indicate that a validation error occured.

This change is upstreamed from U-Boot v2025.07-rc2-26-g9349fc2e9c7 [1].

Link: https://source.denx.de/u-boot/u-boot/-/commit/9349fc2e9c76d042f424edfa69cf421225bf0fcc [1]