### PR TITLE
doxygen: added missing in-group definitions and typos

### DIFF
--- a/src/api/netifapi.c
+++ b/src/api/netifapi.c
@@ -9,6 +9,10 @@
  * @defgroup netifapi_netif NETIF related
  * @ingroup netifapi
  * To be called from non-TCPIP threads
+ *
+ * @defgroup netifapi_arp NETIF ARP
+ * @ingroup netifapi
+ * To be called from non-TCPIP threads
  */
 
 /*

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -1638,7 +1638,7 @@ tcp_seg_free(struct tcp_seg *seg)
 }
 
 /**
- * @ingroup tcp
+ * @ingroup tcp_raw
  * Sets the priority of a connection.
  *
  * @param pcb the tcp_pcb to manipulate

--- a/src/include/lwip/ip_addr.h
+++ b/src/include/lwip/ip_addr.h
@@ -164,7 +164,7 @@ extern const ip_addr_t ip_addr_any_type;
 /** @ingroup ipaddr */
 #define ip_addr_set_zero(ipaddr)     do{ \
   ip6_addr_set_zero(ip_2_ip6(ipaddr)); IP_SET_TYPE(ipaddr, 0); }while(0)
-/** @ingroup ip5addr */
+/** @ingroup ip4addr */
 #define ip_addr_set_zero_ip4(ipaddr)     do{ \
   ip6_addr_set_zero(ip_2_ip6(ipaddr)); IP_SET_TYPE(ipaddr, IPADDR_TYPE_V4); }while(0)
 /** @ingroup ip6addr */


### PR DESCRIPTION
The latest state of the project fails to generate the doxygen documentation due to typos and missing in-groups definitions.
In this PR changes were added to make it buildable again.