### PR TITLE
lwiperf: fix bandwidth calculation precision

### DIFF
--- a/src/apps/lwiperf/lwiperf.c
+++ b/src/apps/lwiperf/lwiperf.c
@@ -236,7 +236,9 @@ lwip_tcp_conn_report(lwiperf_state_tcp_t *conn, enum lwiperf_report_type report_
     if (duration_ms == 0) {
       bandwidth_kbitpsec = 0;
     } else {
-      bandwidth_kbitpsec = (conn->bytes_transferred / duration_ms) * 8U;
+      u64_t bits = (u64_t)conn->bytes_transferred * 8U;
+      /* bandwidth in kbit/s (bits/ms; 1 kbit/s == 1 bit/ms) */
+      bandwidth_kbitpsec = (u32_t)(bits / duration_ms);
     }
     conn->report_fn(conn->report_arg, report_type,
                     &conn->conn_pcb->local_ip, conn->conn_pcb->local_port,


### PR DESCRIPTION
Fix incorrect integer truncation in lwiperf bandwidth calculation.

Current implementation divides bytes_transferred by duration_ms before multiplying by 8,
which leads to loss of precision.

Fix uses 64-bit arithmetic to compute bits first, then divides by time.

No API changes.