### PR TITLE
[STABLE-2_1_x] backport CVE-2026-8836: bound SNMPv3 auth/priv param length (snmp_msg.c)

### DIFF
--- a/src/apps/snmp/snmp_msg.c
+++ b/src/apps/snmp/snmp_msg.c
@@ -921,9 +921,9 @@ snmp_parse_inbound_frame(struct snmp_request *request)
     inbound_msgAuthenticationParameters_offset = pbuf_stream.offset;
     LWIP_UNUSED_ARG(inbound_msgAuthenticationParameters_offset);
     /* Read auth parameters */
-    /* IF_PARSE_ASSERT(tlv.value_len <= SNMP_V3_MAX_AUTH_PARAM_LENGTH); */
+    IF_PARSE_ASSERT(tlv.value_len <= SNMP_V3_MAX_AUTH_PARAM_LENGTH);
     IF_PARSE_EXEC(snmp_asn1_dec_raw(&pbuf_stream, tlv.value_len, request->msg_authentication_parameters,
-                                    &u16_value, tlv.value_len));
+                                    &u16_value, SNMP_V3_MAX_AUTH_PARAM_LENGTH));
     request->msg_authentication_parameters_len = (u8_t)u16_value;
 
     /* msgPrivacyParameters */


### PR DESCRIPTION
STABLE-2_1_x is missing the SNMPv3 inbound-parameter length fix that's on master (0c957ec0). On this branch snmp_msg.c still passes the attacker-controlled tlv.value_len straight into snmp_asn1_dec_raw as both the read length and buf_max_len, and the IF_PARSE_ASSERT that should bound it to SNMP_V3_MAX_AUTH_PARAM_LENGTH is commented out — so a crafted v3 message overruns the fixed 12-byte msg_authentication_parameters[].

I checked it actually reaches the overflow on STABLE-2_1_x (not just a missing line): built the auth-param decode path with -fsanitize=address on ubuntu:22.04 and fed a v3 frame whose auth param is 64 bytes. Pre-fix, ASan reports a buffer-overflow WRITE past the 12-byte region in snmp_pbuf_stream_read <- snmp_asn1_dec_raw <- the auth-param decode. With 0c957ec0 cherry-picked the length guard rejects the frame (ERR_BUF) and there's no write. Real-world reach depends on the firmware enabling the SNMPv3 agent, but the parse path is unconditional once it is.

Cherry-picked clean with `-x` (no conflict), original author preserved. Happy to rebase or adjust if you'd prefer a narrower diff.

upstream fix: https://github.com/lwip-tcpip/lwip/commit/0c957ec03054eb6c8205e9c9d1d05d90ada3898c
CVE-2026-8836